### PR TITLE
Feat/#8 save origin image use case

### DIFF
--- a/lib/domain/common/file/repository/file_repository.dart
+++ b/lib/domain/common/file/repository/file_repository.dart
@@ -1,0 +1,3 @@
+abstract interface class FileRepository {
+  Future<bool> saveData({required List<int> data});
+}

--- a/lib/domain/common/file/use_case/save_origin_image_use_case.dart
+++ b/lib/domain/common/file/use_case/save_origin_image_use_case.dart
@@ -1,0 +1,15 @@
+import 'package:weaco/domain/common/file/repository/file_repository.dart';
+
+class SaveOriginImageUseCase {
+  final FileRepository _fileRepository;
+
+  SaveOriginImageUseCase({required FileRepository fileRepository})
+      : _fileRepository = fileRepository;
+
+  /// 레포지토리에 데이터를 전달하여 저장을 요청
+  /// @param data: 저장할 데이터
+  /// @return: 데이터 저장 성공 여부 반환
+  Future<bool> execute({required List<int> data}) async {
+    return await _fileRepository.saveData(data: data);
+  }
+}

--- a/test/domain/common/file/save_origin_image_use_case.dart
+++ b/test/domain/common/file/save_origin_image_use_case.dart
@@ -1,0 +1,52 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:weaco/domain/common/file/use_case/SaveOriginImageUseCase.dart';
+
+import '../../../mock/data/common/repository/mock_file_repository_impl.dart';
+
+void main() {
+  group('SaveOriginImageUseCase 클래스', () {
+    final mockFileRepository = MockFileRepositoryImpl();
+    final SaveOriginImageUseCase useCase =
+        SaveOriginImageUseCase(fileRepository: mockFileRepository);
+
+    setUp(() => mockFileRepository.initMockData());
+
+    group('execute 메서드는', () {
+      test('FileRepository.saveData()을 한번 호출한다.', () async {
+        // Given
+        const expectCount = 1;
+        const data = <int>[];
+
+        // When
+        await useCase.execute(data: data);
+
+        // Then
+        expect(mockFileRepository.saveDataCallCount, expectCount);
+      });
+
+      test('인자로 data를 FileRepository.saveData()에 그대로 전달한다.', () async {
+        // Given
+        const data = <int>[1, 2, 3];
+
+        // When
+        await useCase.execute(data: data);
+
+        // Then
+        expect(mockFileRepository.methodParameterMap['data'], data);
+      });
+
+      test('FileRepository.saveData()을 호출하고 반환 받은 값을 그대로 반환한다.', () async {
+        // Given
+        const data = <int>[1, 2, 3];
+        bool expectResult = false;
+        mockFileRepository.fakeSaveDataResult = expectResult;
+
+        // When
+        final result = await mockFileRepository.saveData(data: data);
+
+        // Then
+        expect(result, expectResult);
+      });
+    });
+  });
+}

--- a/test/domain/common/file/save_origin_image_use_case.dart
+++ b/test/domain/common/file/save_origin_image_use_case.dart
@@ -1,5 +1,5 @@
 import 'package:flutter_test/flutter_test.dart';
-import 'package:weaco/domain/common/file/use_case/SaveOriginImageUseCase.dart';
+import 'package:weaco/domain/common/file/use_case/save_origin_image_use_case.dart';
 
 import '../../../mock/data/common/repository/mock_file_repository_impl.dart';
 

--- a/test/domain/user/use_case/get_user_page_user_profile_use_case.dart
+++ b/test/domain/user/use_case/get_user_page_user_profile_use_case.dart
@@ -16,7 +16,7 @@ void main() {
       mockUserProfileRepository.resetProfile();
     });
 
-    group('getUserProfile 메서드는', () {
+    group('execute 메서드는', () {
       test('UserProfileRepository.getUserProfile()을 한번 호출한다.', () async {
         // Given
         const expectCount = 1;

--- a/test/mock/data/common/repository/mock_file_repository_impl.dart
+++ b/test/mock/data/common/repository/mock_file_repository_impl.dart
@@ -1,0 +1,20 @@
+import 'package:weaco/domain/common/file/repository/file_repository.dart';
+
+class MockFileRepositoryImpl implements FileRepository {
+  int saveDataCallCount = 0;
+  final Map<String, dynamic> methodParameterMap = {};
+  bool fakeSaveDataResult = false;
+
+  void initMockData() {
+    saveDataCallCount = 0;
+    methodParameterMap.clear();
+    fakeSaveDataResult = false;
+  }
+
+  @override
+  Future<bool> saveData({required List<int> data}) async {
+    saveDataCallCount++;
+    methodParameterMap['data'] = data;
+    return fakeSaveDataResult;
+  }
+}


### PR DESCRIPTION
## :: 최근 작업 주제 (하나 이상의 주제를 선택해주세요.)
- [X] 기능 추가
- [ ] 리뷰 반영
- [X] 리팩토링
- [ ] 버그 수정
- [ ] 컨벤션 수정

<br />

## :: 구현 목표 (해당 브랜치에서 구현하고자 하는 하나의 목표를 설정합니다.)
- SaveOriginImageUseCase 작성

<br />

## :: 구현 사항 설명 (작업한 내용을 상세하게 기록합니다.)
1. FileRepository 인터페이스 생성
2. FileRepository 인터페이스에 saveData 추상 메서드 추가
3. SaveOriginImageUseCase 작성
4. SaveOriginImageUseCase 테스트 코드 작성

<br />

## :: 성장 포인트 (해당 기능을 구현하며 고민했던 사항이나 새로 알게된 부분, 어려웠던 점 등을 작성합니다.)


<br />

## :: 기타 질문 및 특이 사항
- 이미지/파일 저장 방법을 검색해보니 대부분 바이트 어레이를 저장하는 방식이라, 파라미터의 타입을 List<int>로 하였습니다.
- 이미지 저장을 파일로 앱의 temporary directory에 저장하도록 하였습니다.
- domain layer의 common에 이미지 및 파일 저장을 담당하는 FileRepository를 작성하였습니다. 