### PR TITLE
Feat/#6 get my page user profile use case

### DIFF
--- a/lib/domain/user/repository/user_profile_repository.dart
+++ b/lib/domain/user/repository/user_profile_repository.dart
@@ -2,4 +2,6 @@ import 'package:weaco/domain/user/model/user_profile.dart';
 
 abstract interface class UserProfileRepository {
   Future<UserProfile?> getUserProfile({required String email});
+
+  Future<UserProfile?> getMyProfile();
 }

--- a/lib/domain/user/use_case/get_my_page_user_profile_use_case.dart
+++ b/lib/domain/user/use_case/get_my_page_user_profile_use_case.dart
@@ -1,0 +1,16 @@
+import 'package:weaco/domain/user/repository/user_profile_repository.dart';
+import 'package:weaco/domain/user/model/user_profile.dart';
+
+class GetMyPageUserProfileUseCase {
+  final UserProfileRepository _userProfileRepository;
+
+  GetMyPageUserProfileUseCase(
+      {required UserProfileRepository userProfileRepository})
+      : _userProfileRepository = userProfileRepository;
+
+  /// 레포지토리에 내 프로필을 요청
+  /// @return: 내 프로필, 없을 경우 null
+  Future<UserProfile?> execute() async {
+    return await _userProfileRepository.getMyProfile();
+  }
+}

--- a/test/domain/user/use_case/get_my_page_user_profile_use_case_test.dart
+++ b/test/domain/user/use_case/get_my_page_user_profile_use_case_test.dart
@@ -1,0 +1,51 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:weaco/domain/user/model/user_profile.dart';
+import 'package:weaco/domain/user/use_case/get_my_page_user_profile_use_case.dart';
+import '../../../mock/data/user/repository/mock_user_profile_repository_impl.dart';
+
+void main() {
+  group('GetMyPageUserProfileUseCase 클래스', () {
+    final mockUserProfileRepository = MockUserProfileRepositoryImpl();
+    final GetMyPageUserProfileUseCase useCase = GetMyPageUserProfileUseCase(
+        userProfileRepository: mockUserProfileRepository);
+
+    setUp(() {
+      mockUserProfileRepository.resetCallCount();
+      mockUserProfileRepository.resetProfile();
+    });
+
+    group('execute 메서드는', () {
+      test('UserProfileRepository.getMyProfile()을 한번 호출한다.', () async {
+        // Given
+        const expectCount = 1;
+
+        // When
+        await useCase.execute();
+
+        // Then
+        expect(mockUserProfileRepository.getMyProfileCallCount, expectCount);
+      });
+
+      test('UserProfileRepository.getMyProfile()를 호출하고 반환 받은 값을 그대로 반환한다.',
+          () async {
+        // Given
+        const validEmail = 'abcd@gmail.com';
+        final expectProfile = UserProfile(
+            email: validEmail,
+            nickname: '테스트',
+            gender: 1,
+            profileImagePath:
+                'https://health.chosun.com/site/data/img_dir/2024/01/22/2024012201607_0.jpg',
+            feedCount: 0,
+            createdAt: DateTime.parse('2024-05-01 13:27:00'));
+        mockUserProfileRepository.addMyProfile(profile: expectProfile);
+
+        // When
+        final profile = await useCase.execute();
+
+        // Then
+        expect(profile, expectProfile);
+      });
+    });
+  });
+}

--- a/test/mock/data/user/repository/mock_user_profile_repository_impl.dart
+++ b/test/mock/data/user/repository/mock_user_profile_repository_impl.dart
@@ -3,6 +3,8 @@ import 'package:weaco/domain/user/repository/user_profile_repository.dart';
 
 class MockUserProfileRepositoryImpl implements UserProfileRepository {
   int getUserProfileCallCount = 0;
+  int getMyProfileCallCount = 0;
+
   // 메서드 호출시 인자 확인을 위한 map
   final Map<String, dynamic> methodParameterMap = {};
   final Map<String, UserProfile> _fakeUserProfileMap = {};
@@ -22,8 +24,27 @@ class MockUserProfileRepositoryImpl implements UserProfileRepository {
     _fakeUserProfileMap[profile.email] = profile;
   }
 
+  /// [_fakeUserProfileMap]에 마이 프로필을 추가
+  void addMyProfile({required UserProfile profile}) {
+    _fakeUserProfileMap['my'] = profile;
+  }
+
   /// [_fakeUserProfileMap]의 모든 프로필 삭제
   void resetProfile() {
     _fakeUserProfileMap.clear();
+  }
+
+  /// 호출 횟수 초기화
+  void resetCallCount() {
+    getUserProfileCallCount = 0;
+    getMyProfileCallCount = 0;
+  }
+
+  /// 호출시 [getMyProfileCallCount] + 1
+  /// [_fakeUserProfileMap]에서 'my'에 해당하는 프로필을 반환
+  @override
+  Future<UserProfile?> getMyProfile() async {
+    getMyProfileCallCount++;
+    return _fakeUserProfileMap['my'];
   }
 }


### PR DESCRIPTION
## :: 최근 작업 주제 (하나 이상의 주제를 선택해주세요.)
- [x] 기능 추가
- [ ] 리뷰 반영
- [ ] 리팩토링
- [ ] 버그 수정
- [ ] 컨벤션 수정

<br />

## :: 구현 목표 (해당 브랜치에서 구현하고자 하는 하나의 목표를 설정합니다.)
- 마이페이지 프로필 정보 불러오는 usecase 작성

<br />

## :: 구현 사항 설명 (작업한 내용을 상세하게 기록합니다.)
1. 내 프로필 정보 불러오는 usecase 작성

<br />

## :: 성장 포인트 (해당 기능을 구현하며 고민했던 사항이나 새로 알게된 부분, 어려웠던 점 등을 작성합니다.)
- UserProfileRepository 에서 내 프로필 정보를 불러오는 로직인데 내 프로필의 경우 로그인한 유저의 데이터를 가져오기 떄문에
로컬의 데이터를 가져와야 합니다. 그래서 LocalUserProfileRepository를 만들어 분리시킬까에 대한 고민을 하다가 개발 생산성이 떨어지는것 같아 UserProfileRepository에서 My Profile을 가져오는 추상메소드를 추가하고 진행하였습니다.
<br />

## :: 기타 질문 및 특이 사항
LocalUserProfileRepository로 분리시킬지에 대한 의견이 궁금합니다.