### PR TITLE
Feat/#14 get origin image use case

### DIFF
--- a/lib/domain/common/file/repository/file_repository.dart
+++ b/lib/domain/common/file/repository/file_repository.dart
@@ -1,3 +1,6 @@
+import 'dart:io';
+
 abstract interface class FileRepository {
   Future<bool> saveData({required List<int> data});
+  Future<File?> getOriginImage();
 }

--- a/lib/domain/common/file/use_case/get_origin_image_use_case.dart
+++ b/lib/domain/common/file/use_case/get_origin_image_use_case.dart
@@ -1,0 +1,15 @@
+import 'dart:io';
+import 'package:weaco/domain/common/file/repository/file_repository.dart';
+
+class GetOriginImageUseCase {
+  final FileRepository _fileRepository;
+
+  GetOriginImageUseCase({required FileRepository fileRepository})
+      : _fileRepository = fileRepository;
+
+  /// 레포지토리에 크롭 전 이미지를 요청
+  /// @return: 크롭 전 이미지, 없을 경우 null
+  Future<File?> execute() async {
+    return await _fileRepository.getOriginImage();
+  }
+}

--- a/test/domain/common/file/get_origin_image_use_case_test.dart
+++ b/test/domain/common/file/get_origin_image_use_case_test.dart
@@ -1,0 +1,40 @@
+import 'dart:io';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:weaco/domain/common/file/use_case/get_origin_image_use_case.dart';
+
+import '../../../mock/data/common/file/repository/mock_file_repository_impl.dart';
+
+void main() {
+  group('GetOriginImageUseCase 클래스', () {
+    final mockFileRepository = MockFileRepositoryImpl();
+    final GetOriginImageUseCase useCase =
+    GetOriginImageUseCase(fileRepository: mockFileRepository);
+
+    setUp(() => mockFileRepository.initMockData());
+
+    group('execute 메서드는', () {
+      test('FileRepository.getOriginImage()을 한번 호출한다.', () async {
+        // Given
+        const expectCount = 1;
+
+        // When
+        await useCase.execute();
+
+        // Then
+        expect(mockFileRepository.getOriginImageCallCount, expectCount);
+      });
+
+      test('FileRepository.getOriginImage()을 호출하고 반환 받은 값을 그대로 반환한다.', () async {
+        // Given
+        File? expectResult;
+        mockFileRepository.getOriginImageResult = expectResult;
+
+        // When
+        final result = await mockFileRepository.getOriginImage();
+
+        // Then
+        expect(result, expectResult);
+      });
+    });
+  });
+}

--- a/test/domain/common/file/save_origin_image_use_case.dart
+++ b/test/domain/common/file/save_origin_image_use_case.dart
@@ -1,7 +1,7 @@
 import 'package:flutter_test/flutter_test.dart';
 import 'package:weaco/domain/common/file/use_case/save_origin_image_use_case.dart';
 
-import '../../../mock/data/common/repository/mock_file_repository_impl.dart';
+import '../../../mock/data/common/file/repository/mock_file_repository_impl.dart';
 
 void main() {
   group('SaveOriginImageUseCase 클래스', () {

--- a/test/mock/data/common/file/repository/mock_file_repository_impl.dart
+++ b/test/mock/data/common/file/repository/mock_file_repository_impl.dart
@@ -1,14 +1,24 @@
+import 'dart:io';
 import 'package:weaco/domain/common/file/repository/file_repository.dart';
 
+
 class MockFileRepositoryImpl implements FileRepository {
+  int getOriginImageCallCount = 0;
   int saveDataCallCount = 0;
   final Map<String, dynamic> methodParameterMap = {};
+  File? getOriginImageResult;
   bool fakeSaveDataResult = false;
 
   void initMockData() {
-    saveDataCallCount = 0;
+    getOriginImageCallCount = 0;
     methodParameterMap.clear();
-    fakeSaveDataResult = false;
+    getOriginImageResult = null;
+  }
+
+  @override
+  Future<File?> getOriginImage() async {
+    getOriginImageCallCount++;
+    return getOriginImageResult;
   }
 
   @override


### PR DESCRIPTION
## :: 최근 작업 주제 (하나 이상의 주제를 선택해주세요.)
- [X] 기능 추가
- [ ] 리뷰 반영
- [ ] 리팩토링
- [ ] 버그 수정
- [ ] 컨벤션 수정

<br />

## :: 구현 목표 (해당 브랜치에서 구현하고자 하는 하나의 목표를 설정합니다.)
- GetOriginImageUseCase 작성

<br />

## :: 구현 사항 설명 (작업한 내용을 상세하게 기록합니다.)
1. FileRepository 인터페이스에 saveData 추상 메서드 추가
2. GetOriginImageUseCase 작성
3. GetOriginImageUseCase 테스트 코드 작성


<br />

## :: 성장 포인트 (해당 기능을 구현하며 고민했던 사항이나 새로 알게된 부분, 어려웠던 점 등을 작성합니다.)
- flutter CacheManager를 통해서 temporary directory에 파일 읽고(FIle) 쓰기(ByteArray)가 간단하게 가능하다.

<br />

## :: 기타 질문 및 특이 사항
- 각 레포지토리 개발 완료 후, 메서드명 및 파라미터명을 어느 정도 통일 시켜야 할 것 같습니다.
