### PR TITLE
Feat/#18 undo edit cropped image use case

### DIFF
--- a/lib/domain/common/file/repository/file_repository.dart
+++ b/lib/domain/common/file/repository/file_repository.dart
@@ -1,3 +1,5 @@
 abstract interface class FileRepository {
   Future<bool> saveData({required List<int> data});
+
+  Future<bool> removeCroppedImage();
 }

--- a/lib/domain/common/file/use_case/undo_edit_cropped_image_use_case.dart
+++ b/lib/domain/common/file/use_case/undo_edit_cropped_image_use_case.dart
@@ -1,0 +1,14 @@
+import 'package:weaco/domain/common/file/repository/file_repository.dart';
+
+class UndoEditCroppedImageUseCase {
+  final FileRepository _fileRepository;
+
+  UndoEditCroppedImageUseCase({required FileRepository fileRepository})
+      : _fileRepository = fileRepository;
+
+  /// 레포지토리에 저장된 크롭 이미지에 대한 삭제 요청
+  /// @return: 삭제 성공 여부 반환
+  Future<bool> execute() async {
+    return await _fileRepository.removeCroppedImage();
+  }
+}

--- a/test/domain/common/file/undo_edit_cropped_image_use_case_test.dart
+++ b/test/domain/common/file/undo_edit_cropped_image_use_case_test.dart
@@ -1,0 +1,40 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:weaco/domain/common/file/use_case/undo_edit_cropped_image_use_case.dart';
+
+import '../../../mock/data/common/repository/mock_file_repository_impl.dart';
+
+void main() {
+  group('UndoEditCroppedImageUseCase 클래스', () {
+    final mockFileRepository = MockFileRepositoryImpl();
+    final UndoEditCroppedImageUseCase useCase =
+        UndoEditCroppedImageUseCase(fileRepository: mockFileRepository);
+
+    setUp(() => mockFileRepository.initMockData());
+
+    group('execute 메서드는', () {
+      test('FileRepository.removeCroppedImage()을 한번 호출한다.', () async {
+        // Given
+        const expectCount = 1;
+
+        // When
+        await useCase.execute();
+
+        // Then
+        expect(mockFileRepository.removeCroppedImageCallCount, expectCount);
+      });
+
+      test('FileRepository.removeCroppedImage()을 호출하고 반환 받은 값을 그대로 반환한다.',
+          () async {
+        // Given
+        bool expectResult = false;
+        mockFileRepository.fakeSaveDataResult = expectResult;
+
+        // When
+        final result = await mockFileRepository.removeCroppedImage();
+
+        // Then
+        expect(result, expectResult);
+      });
+    });
+  });
+}

--- a/test/mock/data/common/repository/mock_file_repository_impl.dart
+++ b/test/mock/data/common/repository/mock_file_repository_impl.dart
@@ -2,12 +2,16 @@ import 'package:weaco/domain/common/file/repository/file_repository.dart';
 
 class MockFileRepositoryImpl implements FileRepository {
   int saveDataCallCount = 0;
+  int removeCroppedImageCallCount = 0;
   final Map<String, dynamic> methodParameterMap = {};
   bool fakeSaveDataResult = false;
+  bool fakeRemoveCroppedImageResult = false;
 
   void initMockData() {
     saveDataCallCount = 0;
+    removeCroppedImageCallCount = 0;
     methodParameterMap.clear();
+    fakeRemoveCroppedImageResult = false;
     fakeSaveDataResult = false;
   }
 
@@ -16,5 +20,11 @@ class MockFileRepositoryImpl implements FileRepository {
     saveDataCallCount++;
     methodParameterMap['data'] = data;
     return fakeSaveDataResult;
+  }
+
+  @override
+  Future<bool> removeCroppedImage() async {
+    removeCroppedImageCallCount++;
+    return fakeRemoveCroppedImageResult;
   }
 }


### PR DESCRIPTION
## :: 최근 작업 주제 (하나 이상의 주제를 선택해주세요.)
- [x] 기능 추가
- [ ] 리뷰 반영
- [ ] 리팩토링
- [ ] 버그 수정
- [ ] 컨벤션 수정

<br />

## :: 구현 목표 (해당 브랜치에서 구현하고자 하는 하나의 목표를 설정합니다.)
- cropped image undo usecase 작성 

<br />

## :: 구현 사항 설명 (작업한 내용을 상세하게 기록합니다.)
1. 이전 화면으로 돌아갈때 불필요한 데이터(크롭이미지) 삭제 로직 추가

<br />

## :: 성장 포인트 (해당 기능을 구현하며 고민했던 사항이나 새로 알게된 부분, 어려웠던 점 등을 작성합니다.)
아직 router로 go와 pop중에 정해지지 않아서 origin image의 path를 넘겨주면서 cropped image를 삭제하는 로직과
cropped image만 삭제하는 로직중 cropped image만 삭제하는 방향으로 진행하였고 기획이 바뀌면 수정하도록 할것 같습니다.

<br />

## :: 기타 질문 및 특이 사항
