### PR TITLE
Feat/#30 save edit feed use case

### DIFF
--- a/lib/domain/feed/model/feed.dart
+++ b/lib/domain/feed/model/feed.dart
@@ -2,7 +2,7 @@ import 'package:weaco/domain/location/model/location.dart';
 import 'package:weaco/domain/weather/model/weather.dart';
 
 class Feed {
-  final String id;
+  final String? id;
   final String imagePath;
   final String userEmail;
   final String description;

--- a/lib/domain/feed/repository/feed_repository.dart
+++ b/lib/domain/feed/repository/feed_repository.dart
@@ -16,4 +16,6 @@ abstract interface class FeedRepository {
   Future<Feed?> getFeed({required String id});
 
   Future<Feed?> deleteFeed({required String id});
+
+  Future<bool> saveFeed({required Feed editedFeed});
 }

--- a/lib/domain/feed/use_case/save_edit_feed_use_case.dart
+++ b/lib/domain/feed/use_case/save_edit_feed_use_case.dart
@@ -11,13 +11,6 @@ class SaveEditFeedUseCase {
   /// @param feed: 저장할 피드
   /// @return: 서버 응답 메세지. response 모델로 변경 예정.
   Future<bool> execute({required Feed feed}) async {
-    bool response = false;
-
-    try {
-      response = await _feedRepository.saveFeed(editedFeed: feed);
-    } on Exception catch (e) {
-      Exception(e);
-    }
-    return response;
+    return await _feedRepository.saveFeed(editedFeed: feed);
   }
 }

--- a/lib/domain/feed/use_case/save_edit_feed_use_case.dart
+++ b/lib/domain/feed/use_case/save_edit_feed_use_case.dart
@@ -1,0 +1,23 @@
+import 'package:weaco/domain/feed/model/feed.dart';
+import 'package:weaco/domain/feed/repository/feed_repository.dart';
+
+class SaveEditFeedUseCase {
+  final FeedRepository _feedRepository;
+
+  SaveEditFeedUseCase({required FeedRepository feedRepository})
+      : _feedRepository = feedRepository;
+
+  /// 특정 피드 저장 또는 업데이트
+  /// @param feed: 저장할 피드
+  /// @return: 서버 응답 메세지. response 모델로 변경 예정.
+  Future<bool> execute({required Feed feed}) async {
+    bool response = false;
+
+    try {
+      response = await _feedRepository.saveFeed(editedFeed: feed);
+    } on Exception catch (e) {
+      Exception(e);
+    }
+    return response;
+  }
+}

--- a/test/domain/feed/use_case/save_edit_feed_use_case_test.dart
+++ b/test/domain/feed/use_case/save_edit_feed_use_case_test.dart
@@ -1,0 +1,88 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:weaco/domain/feed/model/feed.dart';
+import 'package:weaco/domain/feed/use_case/save_edit_feed_use_case.dart';
+import 'package:weaco/domain/location/model/location.dart';
+import 'package:weaco/domain/weather/model/weather.dart';
+import '../../../mock/data/feed/repository/mock_feed_repository_impl.dart';
+
+void main() {
+  group('SaveEditFeedUseCase 클래스', () {
+    final feedRepository = MockFeedRepositoryImpl();
+    final saveEditFeedUseCase =
+        SaveEditFeedUseCase(feedRepository: feedRepository);
+
+    setUp(() => feedRepository.initMockData());
+
+    group('execute 메소드는', () {
+      test('파라미터로 받은 새 feed를 FeedRepository.saveFeed에 넘긴다.', () async {
+        // Given
+        const bool expectedResponse = true;
+        const int expectedCallCount = 1;
+
+        final mockFeedNew = Feed(
+          id: '',
+          imagePath: 'imagePath',
+          userEmail: 'userEmail',
+          description: 'description',
+          weather: Weather(
+            temperature: 1,
+            timeTemperature: DateTime.now(),
+            code: 1,
+            createdAt: DateTime.now(),
+          ),
+          seasonCode: 1,
+          location: Location(
+            lat: 1,
+            lng: 1,
+            city: 'city',
+            createdAt: DateTime.now(),
+          ),
+          createdAt: DateTime.now(),
+          deletedAt: null,
+        );
+
+        // When
+        final response = await saveEditFeedUseCase.execute(feed: mockFeedNew);
+
+        // Then
+        expect(feedRepository.saveFeedCallCount, expectedCallCount);
+        expect(response, expectedResponse);
+      });
+
+      test('파라미터로 받은 수정된 feed를 FeedRepository.saveFeed에 넘긴다.', () async {
+        // Given
+        const int expectedCallCount = 1;
+        const bool expectedResponse = true;
+        final editedFeed = Feed(
+          id: 'id',
+          imagePath: 'imagePath',
+          userEmail: 'userEmail',
+          description: 'description',
+          weather: Weather(
+            temperature: 1,
+            timeTemperature: DateTime.now(),
+            code: 1,
+            createdAt: DateTime.now(),
+          ),
+          seasonCode: 1,
+          location: Location(
+            lat: 1,
+            lng: 1,
+            city: 'city',
+            createdAt: DateTime.now(),
+          ),
+          createdAt: DateTime.now(),
+          deletedAt: null,
+        );
+        feedRepository.getFeedResult = editedFeed;
+
+        // When
+        final response = await saveEditFeedUseCase.execute(feed: editedFeed);
+
+        // Then
+        expect(feedRepository.saveFeedCallCount, expectedCallCount);
+        expect(response, expectedResponse);
+      });
+    });
+  });
+}

--- a/test/mock/data/feed/repository/mock_feed_repository_impl.dart
+++ b/test/mock/data/feed/repository/mock_feed_repository_impl.dart
@@ -30,6 +30,7 @@ class MockFeedRepositoryImpl implements FeedRepository {
   }
 
   void initMockData() {
+    saveFeedCallCount = 0;
     getFeedListcallCount = 0;
     getFeedCallCount = 0;
     getRecommendedFeedsCallCount = 0;

--- a/test/mock/data/feed/repository/mock_feed_repository_impl.dart
+++ b/test/mock/data/feed/repository/mock_feed_repository_impl.dart
@@ -6,14 +6,13 @@ class MockFeedRepositoryImpl implements FeedRepository {
   int getFeedCallCount = 0;
   int getRecommendedFeedsCallCount = 0;
   String getFeedParamId = '';
-
   // 메서드 호출시 인자 확인을 위한 map
   final Map<String, dynamic> methodParameterMap = {};
   final List<Feed> _fakeFeedList = [];
   Feed? getFeedResult;
-
   Feed? feed;
   Map<String, dynamic> feedMap = {};
+  int saveFeedCallCount = 0;
 
   @override
   Future<List<Feed>> getFeedList({
@@ -57,7 +56,6 @@ class MockFeedRepositoryImpl implements FeedRepository {
       int? weatherCode,
       int? minTemperature,
       int? maxTemperature}) {
-
     getRecommendedFeedsCallCount++;
     methodParameterMap['seasonCode'] = seasonCode;
     methodParameterMap['weatherCode'] = weatherCode;
@@ -101,5 +99,13 @@ class MockFeedRepositoryImpl implements FeedRepository {
   @override
   Future<Feed?> deleteFeed({required String id}) async {
     return feedMap.remove(id);
+  }
+
+  @override
+  Future<bool> saveFeed({required Feed editedFeed}) async {
+    saveFeedCallCount++;
+    feed = editedFeed;
+    if (editedFeed.id!.isNotEmpty) return true;
+    return true;
   }
 }


### PR DESCRIPTION
## :: 최근 작업 주제 (하나 이상의 주제를 선택해주세요.)
- [x] 기능 추가
- [ ] 리뷰 반영
- [x] 리팩토링
- [ ] 버그 수정
- [ ] 컨벤션 수정

<br />

## :: 구현 목표 (해당 브랜치에서 구현하고자 하는 하나의 목표를 설정합니다.)
- 작성하거나 수정한 피드를 저장하는 유스케이스 작성

<br />

## :: 구현 사항 설명 (작업한 내용을 상세하게 기록합니다.)
1. Feed 모델의 id 타입을 nullable하게 변경
2. FeedRepository에 saveFeed 추상 메서드 추가
3. SaveEditFeedUseCase 작성
4. SaveEditFeedUseCase 테스트 코드 작성

<br />

## :: 성장 포인트 (해당 기능을 구현하며 고민했던 사항이나 새로 알게된 부분, 어려웠던 점 등을 작성합니다.)

<br />

## :: 기타 질문 및 특이 사항
- SaveEditFeedUseCase를 통해 새 피드 작성과 피드 수정을 합니다.
- 새피드 작성 및 피드 수정 시 Feed 객체를 넘겨주기로 설계하였으므로 Feed 모델의 타입 nullable하게 변경하였습니다.
