### PR TITLE
Feat/#26 get edit weather use case

### DIFF
--- a/lib/domain/weather/repository/weather_repository.dart
+++ b/lib/domain/weather/repository/weather_repository.dart
@@ -1,0 +1,5 @@
+import 'package:weaco/domain/weather/model/weather.dart';
+
+abstract interface class WeatherRepository {
+  Future<Weather?> getWeather();
+}

--- a/lib/domain/weather/use_case/get_edit_weather_use_case.dart
+++ b/lib/domain/weather/use_case/get_edit_weather_use_case.dart
@@ -1,0 +1,14 @@
+import 'package:weaco/domain/weather/model/weather.dart';
+import 'package:weaco/domain/weather/repository/weather_repository.dart';
+
+class GetEditWeatherUseCase {
+  final WeatherRepository _weatherRepository;
+
+  const GetEditWeatherUseCase({
+    required WeatherRepository weatherRepository,
+  }) : _weatherRepository = weatherRepository;
+
+  Future<Weather?> execute() async {
+    return await _weatherRepository.getWeather();
+  }
+}

--- a/test/domain/weather/use_case/get_edit_weather_use_case_test.dart
+++ b/test/domain/weather/use_case/get_edit_weather_use_case_test.dart
@@ -1,0 +1,37 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:weaco/domain/weather/model/weather.dart';
+import 'package:weaco/domain/weather/use_case/get_edit_weather_use_case.dart';
+
+import '../../../mock/data/weather/repository/mock_weather_repository.dart';
+
+void main() {
+  final MockWeatherRepository mockWeatherRepository = MockWeatherRepository();
+  final GetEditWeatherUseCase getEditWeatherUseCase =
+      GetEditWeatherUseCase(weatherRepository: mockWeatherRepository);
+
+  group('GetEditWeatherUseCase 클래스', () {
+    group('execute() 메소드는 ', () {
+      test('getWeather() 메소드를 1회 호출한다.', () async {
+        int expectCallCount = 1;
+
+        await getEditWeatherUseCase.execute();
+
+        expect(mockWeatherRepository.getWeatherCallCount, expectCallCount);
+      });
+      test('getWeather() 메소드로 반환받은 값을 그대로 반환한다.', () async {
+        final expectReturnValue = Weather(
+          temperature: 28,
+          timeTemperature: DateTime(2024, 05, 05),
+          code: 0,
+          createdAt: DateTime(2024, 05, 05),
+        );
+
+        mockWeatherRepository.returnValue = expectReturnValue;
+
+        final actualReturnValue = await getEditWeatherUseCase.execute();
+
+        expect(actualReturnValue, expectReturnValue);
+      });
+    });
+  });
+}

--- a/test/mock/data/weather/repository/mock_weather_repository.dart
+++ b/test/mock/data/weather/repository/mock_weather_repository.dart
@@ -1,0 +1,22 @@
+import 'package:weaco/domain/location/model/location.dart';
+import 'package:weaco/domain/weather/model/weather.dart';
+import 'package:weaco/domain/weather/repository/weather_repository.dart';
+
+class MockWeatherRepository implements WeatherRepository {
+  int getWeatherCallCount = 0;
+  Location? methodParameter;
+  Weather? returnValue;
+
+  void initMockData() {
+    getWeatherCallCount = 0;
+    methodParameter = null;
+    returnValue = null;
+  }
+
+  @override
+  Future<Weather?> getWeather({Location? location}) {
+    getWeatherCallCount++;
+    methodParameter = location;
+    return Future.value(returnValue);
+  }
+}


### PR DESCRIPTION
## :: 최근 작업 주제 (하나 이상의 주제를 선택해주세요.)
- [X] 기능 추가
- [ ] 리뷰 반영
- [ ] 리팩토링
- [ ] 버그 수정
- [ ] 컨벤션 수정

## :: 구현 목표 (해당 브랜치에서 구현하고자 하는 하나의 목표를 설정합니다.)
- OOTD 작성 화면에서 현재 Weather 을 가져오는 유스케이스 및 테스트 코드 작성

## :: 구현 사항 설명 (작업한 내용을 상세하게 기록합니다.)
- 기능구현
  - WeatherRepository.getWeather() 메소드를 호출하여 Weather를 가져오도록 구현
  - 실제로 어디서 Weather 정보를 가져올 지는 WeatherRepository 구현체에서 동작하도록 할 예정
- 테스트
  - WeatherRepository.getWeather()는 인자가 없으므로 호출횟수, 반환값에 대해서만 테스트 코드 작성

## :: 기타 질문 및 특이 사항
- DailyLocationWeather 관련 유스케이스가 있어서 실제로 이 유스케이스가 의미가 있는 코드인지 의문이 듬
- OOTD 작성화면으로 진입시 DailyLocationWeather 데이터를 원격에서 가져와서 최신화후 사용하는 것이 변경된 시나리오가 아니었는지 의문
