### PR TITLE
Feat/#147 feed repository facade pattern

### DIFF
--- a/lib/data/feed/repository/ootd_feed_repository_impl.dart
+++ b/lib/data/feed/repository/ootd_feed_repository_impl.dart
@@ -1,0 +1,51 @@
+import 'package:weaco/domain/feed/model/feed.dart';
+import 'package:weaco/domain/feed/repository/feed_repository.dart';
+import 'package:weaco/domain/feed/repository/ootd_feed_repository.dart';
+import 'package:weaco/domain/file/repository/file_repository.dart';
+import 'package:weaco/domain/user/repository/user_profile_repository.dart';
+
+class OotdFeedRepositoryImpl implements OotdFeedRepository {
+  final FileRepository _fileRepository;
+  final FeedRepository _feedRepository;
+  final UserProfileRepository _userProfileRepository;
+
+  const OotdFeedRepositoryImpl({
+    required FileRepository fileRepository,
+    required FeedRepository feedRepository,
+    required UserProfileRepository userProfileRepository,
+  })  : _fileRepository = fileRepository,
+        _feedRepository = feedRepository,
+        _userProfileRepository = userProfileRepository;
+
+  /// 피드 저장
+  @override
+  Future<bool> saveOotdFeed({required Feed feed}) async {
+    final String path = await _fileRepository.saveOotdImage();
+
+    final saveResult = await _feedRepository.saveFeed(
+        editedFeed: feed.copyWith(imagePath: path));
+
+    await _updateMyFeedCount(1);
+
+    return saveResult;
+  }
+
+  /// 피드 삭제
+  @override
+  Future<bool> removeOotdFeed({required String id}) async {
+    await _feedRepository.deleteFeed(id: id);
+
+    await _updateMyFeedCount(-1);
+
+    return true;
+  }
+
+  /// 유저 피드 카운트 업데이트
+  Future<void> _updateMyFeedCount(int count) async {
+    final myProfile = await _userProfileRepository.getMyProfile();
+
+    _userProfileRepository.updateUserProfile(
+        userProfile:
+            myProfile!.copyWith(feedCount: myProfile.feedCount + count));
+  }
+}

--- a/lib/data/user/repository/user_profile_repository_impl.dart
+++ b/lib/data/user/repository/user_profile_repository_impl.dart
@@ -18,4 +18,9 @@ class UserProfileRepositoryImpl implements UserProfileRepository {
   Future<UserProfile?> getUserProfile({required String email}) async {
     return await _remoteUserProfileDataSource.getUserProfile(email: email);
   }
+
+  @override
+  Future<bool> updateUserProfile({required UserProfile userProfile}) async {
+    return await _remoteUserProfileDataSource.updateUserProfile(userProfile: userProfile);
+  }
 }

--- a/lib/domain/feed/repository/ootd_feed_repository.dart
+++ b/lib/domain/feed/repository/ootd_feed_repository.dart
@@ -1,0 +1,7 @@
+import 'package:weaco/domain/feed/model/feed.dart';
+
+abstract interface class OotdFeedRepository {
+  Future<bool> saveOotdFeed({required Feed feed});
+
+  Future<bool> removeOotdFeed({required String id});
+}

--- a/lib/domain/user/repository/user_profile_repository.dart
+++ b/lib/domain/user/repository/user_profile_repository.dart
@@ -4,4 +4,6 @@ abstract interface class UserProfileRepository {
   Future<UserProfile?> getUserProfile({required String email});
 
   Future<UserProfile?> getMyProfile();
+
+  Future<bool> updateUserProfile({required UserProfile userProfile});
 }

--- a/test/data/feed/repository/ootd_feed_repository_impl_test.dart
+++ b/test/data/feed/repository/ootd_feed_repository_impl_test.dart
@@ -143,7 +143,9 @@ void main() {
             expectedUseProfile);
       });
 
-      test('피드 저장 성공 시, true 를 반환한다.', () async {
+      test(''
+          'FeedRepository.saveFeed, UserProfileRepository.updateMyFeedCount()를 '
+          '정상적으로 호출한 뒤, true 를 반환한다.', () async {
         // Given
         const expected = true;
 
@@ -205,7 +207,9 @@ void main() {
         expect(userProfileRepository.methodParameterMap['updateUserProfile'], expectedUserProfile);
       });
 
-      test('피드 삭제 성공 시 true 를 반환한다.', () async {
+      test(
+          'FeedRepository.deleteFeed(), OotdFeedRepositoryImpl.updateMyFeedCount()를 '
+          '정상적으로 호출한 뒤, true 를 반환한다.', () async {
         // Given
         const expected = true;
 

--- a/test/data/feed/repository/ootd_feed_repository_impl_test.dart
+++ b/test/data/feed/repository/ootd_feed_repository_impl_test.dart
@@ -1,0 +1,220 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:weaco/data/feed/repository/ootd_feed_repository_impl.dart';
+import 'package:weaco/domain/feed/model/feed.dart';
+import 'package:weaco/domain/location/model/location.dart';
+import 'package:weaco/domain/user/model/user_profile.dart';
+import 'package:weaco/domain/weather/model/weather.dart';
+
+import '../../../mock/data/feed/repository/mock_feed_repository_impl.dart';
+import '../../../mock/data/file/repository/mock_file_repository_impl.dart';
+import '../../../mock/data/user/repository/mock_user_profile_repository_impl.dart';
+
+void main() {
+  group('OotdFeedRepositoryImpl 클래스', () {
+    final fileRepository = MockFileRepositoryImpl();
+    final feedRepository = MockFeedRepositoryImpl();
+    final userProfileRepository = MockUserProfileRepositoryImpl();
+    final ootdFeedRepository = OotdFeedRepositoryImpl(
+      fileRepository: fileRepository,
+      feedRepository: feedRepository,
+      userProfileRepository: userProfileRepository,
+    );
+    const String feedId = '1';
+
+    final Weather mockWeather = Weather(
+      temperature: 31,
+      timeTemperature: DateTime.parse('2024-05-06'),
+      code: 1,
+      createdAt: DateTime.parse('2024-05-06'),
+    );
+    final Location mockLocation = Location(
+      lat: 31.23,
+      lng: 29.48,
+      city: '서울시, 노원구',
+      createdAt: DateTime.parse('2024-05-06'),
+    );
+    final mockFeed = Feed(
+      id: 'id',
+      imagePath: 'imagePath',
+      userEmail: 'test@email.com',
+      description: 'This is a test feed',
+      weather: mockWeather,
+      seasonCode: 2,
+      location: mockLocation,
+      createdAt: DateTime.parse('2024-05-06'),
+    );
+
+    final mockUserProfile = UserProfile(
+      email: 'email',
+      nickname: 'nickname',
+      gender: 1,
+      profileImagePath: 'profileImagePath',
+      feedCount: 0,
+      createdAt: DateTime.parse('2024-05-06'),
+    );
+
+    setUp(() {
+      fileRepository.initMockData();
+      feedRepository.initMockData();
+      userProfileRepository.resetCallCount();
+      userProfileRepository.resetProfile();
+      userProfileRepository.addMyProfile(profile: mockUserProfile);
+    });
+
+    group('saveOotdFeed 메서드는', () {
+      test('피드를 저장하기 위해 FileRepository.saveOotdImage()를 한 번 호출한다.', () async {
+        // Given
+        const expectedCallCount = 1;
+
+        // When
+        await ootdFeedRepository.saveOotdFeed(feed: mockFeed);
+
+        // Then
+        expect(fileRepository.saveOotdImageCallCount, expectedCallCount);
+      });
+
+      test('피드를 저장하기 위해 FeedRepository.saveFeed()를 한 번 호출한다.', () async {
+        // Given
+        const expectedCallCount = 1;
+
+        // When
+        await ootdFeedRepository.saveOotdFeed(feed: mockFeed);
+
+        // Then
+        expect(feedRepository.saveFeedCallCount, expectedCallCount);
+      });
+
+      test(
+          '파라미터로 받은 feed 에 FileRepository.saveOotdImage()로 받은 path 를 '
+          '추가한 새로운 피드를 FeedRepository.saveFeed()에 전달한다.', () async {
+        // Given
+        const String path = 'abc.jpg';
+        fileRepository.saveOotdImageResult = path;
+
+        // 예상 값
+        final expectedFeed = mockFeed.copyWith(imagePath: path);
+
+        // When
+        await ootdFeedRepository.saveOotdFeed(feed: mockFeed);
+
+        // Then
+        expect(feedRepository.feed, expectedFeed);
+      });
+
+      test(
+          '유저 피드 카운트를 업데이트하기 위해 UserProfileRepository.getMyProfile()를 한 번 호출한다.',
+          () async {
+        // Given
+        const expectedCallCount = 1;
+
+        // When
+        await ootdFeedRepository.saveOotdFeed(feed: mockFeed);
+
+        // Then
+        expect(userProfileRepository.getMyProfileCallCount, expectedCallCount);
+      });
+
+      test(
+          '유저 피드 카운트를 업데이트하기 위해 UserProfileRepository.updateUserProfile()를 한 번 호출한다.',
+          () async {
+        // Given
+        const expectedCallCount = 1;
+
+        // When
+        await ootdFeedRepository.saveOotdFeed(feed: mockFeed);
+
+        // Then
+        expect(userProfileRepository.updateUserProfileCallCount,
+            expectedCallCount);
+      });
+
+      test(
+          '가져온 유저 피드 카운트에 1을 더한 userProfile 을 '
+          'UserProfileRepository.updateUserProfile()에 전달한다.', () async {
+        // Given
+        final expectedUseProfile =
+            mockUserProfile.copyWith(feedCount: mockUserProfile.feedCount + 1);
+
+        // When
+        await ootdFeedRepository.saveOotdFeed(feed: mockFeed);
+
+        // Then
+        expect(userProfileRepository.methodParameterMap['updateUserProfile'],
+            expectedUseProfile);
+      });
+
+      test('피드 저장 성공 시, true 를 반환한다.', () async {
+        // Given
+        const expected = true;
+
+        // When
+        final actual = await ootdFeedRepository.saveOotdFeed(feed: mockFeed);
+
+        // Then
+        expect(actual, expected);
+      });
+    });
+
+    group('removeOotdFeed 메서드는', () {
+      test('피드를 삭제하기 위해 FeedRepository.deleteFeed()를 한 번 호출한다.', () async {
+        // Given
+        const expectedCallCount = 1;
+
+        // When
+        await ootdFeedRepository.removeOotdFeed(id: feedId);
+
+        // Then
+        expect(feedRepository.getDeleteFeedCallCount, expectedCallCount);
+      });
+
+      test(
+          '유저 피드 카운트를 업데이트하기 위해 UserProfileRepository.getMyProfile()를 한 번 호출한다.',
+          () async {
+        // Given
+        const expectedCallCount = 1;
+
+        // When
+        await ootdFeedRepository.removeOotdFeed(id: feedId);
+
+        // Then
+        expect(userProfileRepository.getMyProfileCallCount, expectedCallCount);
+      });
+
+      test(
+          '유저 피드 카운트를 업데이트하기 위해 UserProfileRepository.updateUserProfile()를 한 번 호출한다.',
+          () async {
+        // Given
+        const expectedCallCount = 1;
+
+        // When
+        await ootdFeedRepository.removeOotdFeed(id: feedId);
+
+        // Then
+        expect(userProfileRepository.updateUserProfileCallCount,
+            expectedCallCount);
+      });
+
+      test('가져온 유저 피드 카운트에 1을 뺀 값을 UserProfileRepository.updateUserProfile()에 전달한다.', () async {
+        // Given
+        final expectedUserProfile = mockUserProfile.copyWith(feedCount: mockUserProfile.feedCount - 1);
+
+        // When
+        await ootdFeedRepository.removeOotdFeed(id: feedId);
+
+        // Then
+        expect(userProfileRepository.methodParameterMap['updateUserProfile'], expectedUserProfile);
+      });
+
+      test('피드 삭제 성공 시 true 를 반환한다.', () async {
+        // Given
+        const expected = true;
+
+        // When
+        final actual = await ootdFeedRepository.removeOotdFeed(id: feedId);
+
+        // Then
+        expect(actual, expected);
+      });
+    });
+  });
+}

--- a/test/domain/user/repository/user_profile_repository_impl_test.dart
+++ b/test/domain/user/repository/user_profile_repository_impl_test.dart
@@ -1,7 +1,7 @@
 import 'package:flutter_test/flutter_test.dart';
 import 'package:weaco/domain/user/model/user_profile.dart';
 import 'package:weaco/domain/user/repository/user_profile_repository.dart';
-import 'package:weaco/domain/user/repository/user_profile_repository_impl.dart';
+import 'package:weaco/data/user/repository/user_profile_repository_impl.dart';
 
 import '../../../mock/data/user/data_source/mock_remote_user_profile_data_source.dart';
 

--- a/test/mock/data/feed/repository/mock_feed_repository_impl.dart
+++ b/test/mock/data/feed/repository/mock_feed_repository_impl.dart
@@ -8,6 +8,7 @@ class MockFeedRepositoryImpl implements FeedRepository {
   int getRecommendedFeedsCallCount = 0;
   int getOotdFeedsListCallCount = 0;
   int getSearchFeedsCallCount = 0;
+  int getDeleteFeedCallCount = 0;
   String getFeedParamId = '';
 
   // 메서드 호출시 인자 확인을 위한 map
@@ -150,6 +151,7 @@ class MockFeedRepositoryImpl implements FeedRepository {
 
   @override
   Future<Feed?> deleteFeed({required String id}) async {
+    getDeleteFeedCallCount++;
     return feedMap.remove(id);
   }
 

--- a/test/mock/data/file/repository/mock_file_repository_impl.dart
+++ b/test/mock/data/file/repository/mock_file_repository_impl.dart
@@ -4,14 +4,18 @@ import 'package:weaco/domain/file/repository/file_repository.dart';
 class MockFileRepositoryImpl implements FileRepository {
   int getImageCallCount = 0;
   int saveImageCallCount = 0;
+  int saveOotdImageCallCount = 0;
   final Map<String, dynamic> methodParameterMap = {};
   File? getImageResult;
+  String saveOotdImageResult = '';
   bool saveImageResult = false;
 
   void initMockData() {
     getImageCallCount = 0;
     saveImageCallCount = 0;
+    saveOotdImageCallCount = 0;
     methodParameterMap.clear();
+    saveOotdImageResult = '';
   }
 
   @override
@@ -28,8 +32,8 @@ class MockFileRepositoryImpl implements FileRepository {
   }
 
   @override
-  Future<String> saveOotdImage() {
-    // TODO: implement saveFeed
-    throw UnimplementedError();
+  Future<String> saveOotdImage() async {
+    saveOotdImageCallCount++;
+    return saveOotdImageResult;
   }
 }

--- a/test/mock/data/user/repository/mock_user_profile_repository_impl.dart
+++ b/test/mock/data/user/repository/mock_user_profile_repository_impl.dart
@@ -4,6 +4,8 @@ import 'package:weaco/domain/user/repository/user_profile_repository.dart';
 class MockUserProfileRepositoryImpl implements UserProfileRepository {
   int getUserProfileCallCount = 0;
   int getMyProfileCallCount = 0;
+  int updateUserProfileCallCount = 0;
+  bool updateUserProfileResult = false;
 
   // 메서드 호출시 인자 확인을 위한 map
   final Map<String, dynamic> methodParameterMap = {};
@@ -32,12 +34,14 @@ class MockUserProfileRepositoryImpl implements UserProfileRepository {
   /// [_fakeUserProfileMap]의 모든 프로필 삭제
   void resetProfile() {
     _fakeUserProfileMap.clear();
+    updateUserProfileResult = false;
   }
 
   /// 호출 횟수 초기화
   void resetCallCount() {
     getUserProfileCallCount = 0;
     getMyProfileCallCount = 0;
+    updateUserProfileCallCount = 0;
   }
 
   /// 호출시 [getMyProfileCallCount] + 1
@@ -46,6 +50,13 @@ class MockUserProfileRepositoryImpl implements UserProfileRepository {
   Future<UserProfile?> getMyProfile() async {
     getMyProfileCallCount++;
     return _fakeUserProfileMap['my'];
+  }
+
+  @override
+  Future<bool> updateUserProfile({required UserProfile userProfile}) async {
+    ++updateUserProfileCallCount;
+    methodParameterMap['updateUserProfile'] = userProfile;
+    return updateUserProfileResult;
   }
 }
 


### PR DESCRIPTION
## :: 최근 작업 주제 (하나 이상의 주제를 선택해주세요.)
- [x] 기능 추가
- [ ] 리뷰 반영
- [ ] 리팩토링
- [ ] 버그 수정
- [ ] 컨벤션 수정

<br />

## :: 구현 목표 (해당 브랜치에서 구현하고자 하는 하나의 목표를 설정합니다.)
- Feed 퍼사드 레포지토리 작성

<br />

## :: 구현 사항 설명 (작업한 내용을 상세하게 기록합니다.)
1. FeedRepository, FileRepository, UserProfileRepository로 Feed 퍼사드 레포지토리 작성
2. UserProfileRepositoryImpl 에서 Firebase의 UserProfile 업데이트 메소드 작성
=> 로컬은 뷰 모델에서 처리하기 때문에 여기선 remote profile만 처리
3. 피드 업로드 후 , 프로필에서 게시물 +1, 카운트 +1
4. 피드 삭제 후 , 프로필에서 게시물 -1, 카운트 -1
5. 테스트 코드 작성

<br />

## :: 성장 포인트 (해당 기능을 구현하며 고민했던 사항이나 새로 알게된 부분, 어려웠던 점 등을 작성합니다.)
- 퍼사드 패턴을 사용해봤습니다.
- 테스트 케이스 작게 자르기(코드 한 줄마다 테스트가 가능하다는 것을 배웠습니다.)
- 테스트 코드의 mock 객체 흐름에 대한 이해도를 높였습니다.

<copyWith 테스트>
1. 테스트할 클래스 생성자에 mock 객체들을 넣는다.
2. 예상 값으로 mock 모델의 copyWith에 새 값을 넣어주고
3. When을 실행하면 내부의 (mock) _feedRepository.saveFeed()가 실행된다.
4. MockFeedRepositoryImpl.saveFeed()의 매개변수 editedFeed에는
5. editedFeed에는 feed.copyWith(imagePath: path) 즉, 새롭게 저장된 path가 전달된다.
6. 새롭게 저장된 path를 가진 feed를 Then에서 mock과 비교한다.

<img width="585" alt="image" src="https://github.com/Team-Weather/flutter-wea-co/assets/73895803/6103d2a3-b258-4bdf-9afa-f47dcaf41760">


```dart
class OotdFeedRepositoryImpl implements OotdFeedRepository {
  @override
    Future<bool> saveOotdFeed({required Feed feed}) async {
      final String path = await _fileRepository.saveOotdImage();
  
      final saveResult = await _feedRepository.saveFeed(
          editedFeed: feed.copyWith(imagePath: path));
  
      await _updateMyFeedCount(1);
  
      return saveResult;
    }
}
```

```dart
class MockFeedRepositoryImpl implements FeedRepository {
  Feed? feed;

  @override
  Future<bool> saveFeed({required Feed editedFeed}) async {
    feed = editedFeed;
  }
}
``` 

<br />

## :: 기타 질문 및 특이 사항
