### PR TITLE
Feat/#51 ootd UI view model

### DIFF
--- a/lib/core/go_router/router.dart
+++ b/lib/core/go_router/router.dart
@@ -2,6 +2,9 @@ import 'package:go_router/go_router.dart';
 import 'package:weaco/core/enum/router_path.dart';
 import 'package:weaco/main.dart';
 import 'package:weaco/presentation/home/home_screen.dart';
+import 'package:provider/provider.dart';
+import 'package:weaco/presentation/ootd_feed/view/ootd_feed_screen.dart';
+import 'package:weaco/presentation/ootd_feed/view_model/ootd_feed_view_model.dart';
 
 final router = GoRouter(
   initialLocation: '/',
@@ -51,8 +54,12 @@ final router = GoRouter(
     ),
     GoRoute(
       path: RouterPath.ootdFeed.path,
-      // builder: (context, state) => OotdFeedScreen(),
-      builder: (context, state) => const HomeScreen(),
+      builder: (context, state) {
+        return ChangeNotifierProvider(
+          create: (_) => OotdFeedViewModel(),
+          child: OotdFeedScreen(),
+        );
+      },
     ),
     GoRoute(
       path: RouterPath.ootdDetail.path,

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -96,7 +96,7 @@ class _MyHomePageState extends State<MyHomePage> {
               child: const Text('Go to OotdSearchScreen'),
             ),
             TextButton(
-              onPressed: () {},
+              onPressed: () => RouterStatic.goToOotdFeed(context),
               child: const Text('Go to OotdFeedScreen'),
             ),
             TextButton(

--- a/lib/presentation/ootd_feed/ootd_card.dart
+++ b/lib/presentation/ootd_feed/ootd_card.dart
@@ -1,0 +1,15 @@
+import 'package:weaco/domain/feed/model/feed.dart';
+
+class OotdCard {
+  bool _isFront = true;
+  final Feed _feed;
+
+  OotdCard({required Feed data}) : _feed = data;
+
+
+  Feed get feed => _feed;
+
+  bool get isFront => _isFront;
+
+  set isFront(bool value)  => _isFront = value;
+}

--- a/lib/presentation/ootd_feed/view/flip_card.dart
+++ b/lib/presentation/ootd_feed/view/flip_card.dart
@@ -1,0 +1,291 @@
+import 'dart:math';
+import 'package:flutter/material.dart';
+import 'package:weaco/core/go_router/router_static.dart';
+import 'package:weaco/presentation/ootd_feed/ootd_card.dart';
+
+import 'ootd_feed_screen.dart';
+
+BoxShadow shadow = BoxShadow(
+  color: Colors.black26,
+  blurRadius: 10.0, // soften the shadow
+  spreadRadius: 0.5, //extend the shadow
+);
+
+class FlipCard extends StatefulWidget {
+  final OotdCard _data;
+  final void Function({required bool isToNext}) _moveCallback;
+  final void Function() _flipCallback;
+
+  FlipCard(
+      {required OotdCard data,
+      required void Function({required bool isToNext}) moveCallback,
+      required void Function() flipCallback})
+      : _data = data,
+        _moveCallback = moveCallback,
+        _flipCallback = flipCallback;
+
+  @override
+  _FlipCardState createState() => _FlipCardState(_data.isFront);
+}
+
+class _FlipCardState extends State<FlipCard>
+    with SingleTickerProviderStateMixin {
+  double _swipeThreshold = 100.0;
+  double _swipeStartPoint = 0.0;
+  bool _isSwapping = false;
+  int _flipSpeed = 400;
+  double _flipThreshold = 50.0;
+  double _dragStartPoint = 0.0;
+  bool _isDragging = false;
+  bool _isFlipping = false;
+  bool _isKeepGoingDown = true;
+  bool _isToBack;
+  late AnimationController _controller;
+  late Animation<double> _upAnimation;
+  late Animation<double> _downAnimation;
+
+  _FlipCardState(bool isToBack) : _isToBack = isToBack;
+
+  @override
+  void initState() {
+    _controller = AnimationController(
+        vsync: this, duration: Duration(milliseconds: _flipSpeed));
+    _upAnimation = TweenSequence([
+      TweenSequenceItem(tween: Tween(begin: 0.0, end: -pi / 2), weight: 0.5),
+      TweenSequenceItem(tween: ConstantTween(0.0), weight: 0.5),
+    ]).animate(_controller);
+    _downAnimation = TweenSequence([
+      TweenSequenceItem(tween: ConstantTween(pi / 2), weight: 0.5),
+      TweenSequenceItem(tween: Tween(begin: pi / 2, end: 0.0), weight: 0.5),
+    ]).animate(_controller);
+    super.initState();
+  }
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    super.dispose();
+  }
+
+  void _flip({required bool isUp}) {
+    widget._flipCallback();
+    _isFlipping = true;
+    if (_isKeepGoingDown && !isUp) _isToBack = !_isToBack;
+    if (!_isKeepGoingDown && isUp) _isToBack = !_isToBack;
+    _isKeepGoingDown = !isUp;
+    (isUp ? _controller.forward(from: 0) : _controller.reverse(from: 1)).then(
+      (value) {
+        _isFlipping = false;
+      },
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return GestureDetector(
+      onTap: () {
+        RouterStatic.goToOotdDetail(context);
+      },
+      onHorizontalDragStart: (details) {
+        _swipeStartPoint = details.localPosition.dx;
+        _isSwapping = true;
+      },
+      onHorizontalDragUpdate: (details) {
+        if (!_isSwapping) return;
+        if (_swipeStartPoint - details.localPosition.dx >= _swipeThreshold) {
+          _isSwapping = false;
+          widget._moveCallback(isToNext: true);
+        } else if (_swipeStartPoint - details.localPosition.dx <=
+            -_swipeThreshold) {
+          _isSwapping = false;
+          widget._moveCallback(isToNext: false);
+        }
+      },
+      onVerticalDragStart: (details) {
+        _dragStartPoint = details.localPosition.dy;
+        _isDragging = true;
+      },
+      onVerticalDragUpdate: (details) {
+        if (!_isDragging || _isFlipping) return;
+        if (_dragStartPoint - details.localPosition.dy >= _flipThreshold) {
+          _isDragging = false;
+          _flip(isUp: true);
+          widget._flipCallback();
+        } else if (_dragStartPoint - details.localPosition.dy <=
+            -_flipThreshold) {
+          _isDragging = false;
+          _flip(isUp: false);
+        }
+      },
+      child: Stack(
+        alignment: Alignment.center,
+        children: [
+          SizedBox(
+            width: cardWidth,
+            height: cardHeight,
+            child: AnimatedBuilder(
+              animation: _downAnimation,
+              builder: (_, __) {
+                return Transform(
+                  alignment: Alignment.center,
+                  transform: Matrix4.identity()
+                    ..setEntry(3, 2, 0.0005)
+                    ..rotateX(_downAnimation.value),
+                  child: Visibility(
+                    visible: _controller.value >= 0.5,
+                    child: _isToBack ? _buildBackSide() : _buildFrontSide(),
+                  ),
+                );
+              },
+            ),
+          ),
+          SizedBox(
+            width: cardWidth,
+            height: cardHeight,
+            child: AnimatedBuilder(
+              animation: _upAnimation,
+              builder: (_, __) {
+                return Transform(
+                  alignment: Alignment.center,
+                  transform: Matrix4.identity()
+                    ..setEntry(3, 2, 0.0005)
+                    ..rotateX(_upAnimation.value),
+                  child: Visibility(
+                    visible: _controller.value < 0.5,
+                    child: _isToBack ? _buildFrontSide() : _buildBackSide(),
+                  ),
+                );
+              },
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildFrontSide() {
+    return Container(
+      decoration: BoxDecoration(
+        borderRadius: BorderRadius.circular(30),
+        gradient: LinearGradient(
+          begin: Alignment.topLeft,
+          end: Alignment.bottomRight,
+          colors: [
+            Colors.grey[300]!,
+            Colors.grey[200]!,
+          ],
+        ),
+        boxShadow: const [
+          BoxShadow(
+            color: Colors.black26,
+            blurRadius: 10.0, // 얼마나 흩어져
+            spreadRadius: 0.1, // 얼마나 두껍게
+          )
+        ],
+      ),
+      child: ClipRRect(
+        borderRadius: BorderRadius.circular(30),
+        child: Image.network(
+          widget._data.feed.imagePath,
+          fit: BoxFit.fitHeight,
+        ),
+      ),
+    );
+  }
+
+  Widget _buildBackSide() {
+    return Container(
+      decoration: BoxDecoration(
+        borderRadius:BorderRadius.circular(30),
+        color: Colors.white,
+        boxShadow: const [
+          BoxShadow(
+            color: Colors.black26,
+            blurRadius: 10.0, // 얼마나 흩어져
+            spreadRadius: 0.1, // 얼마나 두껍게
+          )
+        ],
+      ),
+      child: Padding(
+        padding: const EdgeInsets.symmetric(vertical: 16),
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.spaceEvenly,
+          crossAxisAlignment: CrossAxisAlignment.center,
+          children: [
+            Text(
+              '너의 날씨는?',
+              style: TextStyle(
+                fontSize: 24,
+                fontWeight: FontWeight.w800,
+              ),
+            ),
+            SizedBox(
+              width: 80,
+              height: 80,
+              child: Image.network(
+                'https://cdn-icons-png.flaticon.com/256/169/169367.png',
+                fit: BoxFit.fill,
+              ),
+            ),
+            Container(
+              height: 130,
+              width: 240,
+              decoration: BoxDecoration(
+                borderRadius: BorderRadius.circular(10),
+                color: Color(0xFFFAFAFA),
+              ),
+              child: Padding(
+                padding: const EdgeInsets.symmetric(vertical: 10),
+                child: Column(
+                  mainAxisAlignment: MainAxisAlignment.spaceAround,
+                  crossAxisAlignment: CrossAxisAlignment.center,
+                  children: [
+                    Container(
+                      decoration: BoxDecoration(
+                        borderRadius: BorderRadius.circular(30),
+                        color: Color(0xFF282828),
+                        boxShadow: const [
+                          BoxShadow(
+                            color: Colors.black26,
+                            blurRadius: 10.0, // 얼마나 흩어져
+                            spreadRadius: 0.1, // 얼마나 두껍게
+                          )
+                        ],
+                      ),
+                      child: Padding(
+                        padding: const EdgeInsets.symmetric(
+                            horizontal: 8, vertical: 4),
+                        child: Text(
+                          '맑아요',
+                          style: TextStyle(
+                            fontSize: 12,
+                            color: Colors.white,
+                            fontWeight: FontWeight.bold,
+                          ),
+                        ),
+                      ),
+                    ),
+                    Text(
+                      '그날의 온도는',
+                      style: TextStyle(
+                        fontSize: 16,
+                        fontWeight: FontWeight.bold,
+                      ),
+                    ),
+                    Text(
+                      '${widget._data.feed.weather.temperature}',
+                      style: TextStyle(
+                        fontSize: 24,
+                        fontWeight: FontWeight.w800,
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/presentation/ootd_feed/view/ootd_feed_screen.dart
+++ b/lib/presentation/ootd_feed/view/ootd_feed_screen.dart
@@ -1,0 +1,74 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+import 'package:weaco/presentation/ootd_feed/view_model/ootd_feed_view_model.dart';
+import 'flip_card.dart';
+
+double scale = 30;
+double cardWidth = 9 * scale;
+double cardHeight = 16 * scale;
+Duration cardMoveSpeed = Duration(milliseconds: 200);
+
+class OotdFeedScreen extends StatefulWidget {
+  const OotdFeedScreen({super.key});
+
+  @override
+  State<OotdFeedScreen> createState() => _OotdFeedScreenState();
+}
+
+class _OotdFeedScreenState extends State<OotdFeedScreen> {
+  late PageController _pageViewController;
+  int _currentIdx = 0;
+
+  @override
+  void initState() {
+    super.initState();
+    _pageViewController = PageController(viewportFraction: 0.8);
+  }
+
+  @override
+  void dispose() {
+    super.dispose();
+    _pageViewController.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      body: PageView(
+        physics: const NeverScrollableScrollPhysics(),
+        controller: _pageViewController,
+        // padEnds: true,
+        pageSnapping: true,
+        children: List.generate(
+           context.watch<OotdFeedViewModel>().feedList.length,
+            (index) => Center(
+                  child: SizedBox(
+                    width: cardWidth,
+                    height: cardHeight,
+                    child: FlipCard(data: context.watch<OotdFeedViewModel>().feedList[index], moveCallback: moveCard, flipCallback: flipCard),
+                  ),
+                )),
+      ),
+    );
+  }
+
+  void moveCard({required bool isToNext}) {
+    int currentLength = context.read<OotdFeedViewModel>().feedList.length;
+    isToNext ? _currentIdx++ : _currentIdx--;
+    if (_currentIdx < 0) _currentIdx = 0;
+    if (_currentIdx + 2 == currentLength) {
+      context.read<OotdFeedViewModel>().loadMorePage();
+    }
+    if (_currentIdx >= currentLength) _currentIdx = currentLength - 1;
+
+    _pageViewController.animateToPage(
+      _currentIdx,
+      duration: cardMoveSpeed,
+      curve: Curves.easeInOut,
+    );
+  }
+
+  void flipCard() {
+    // context.read<OotdFeedViewModel>().flipCard(index: _currentIdx);
+  }
+}

--- a/lib/presentation/ootd_feed/view_model/ootd_feed_view_model.dart
+++ b/lib/presentation/ootd_feed/view_model/ootd_feed_view_model.dart
@@ -1,0 +1,37 @@
+import 'package:flutter/cupertino.dart';
+import 'package:weaco/domain/feed/model/feed.dart';
+import 'package:weaco/domain/location/model/location.dart';
+import 'package:weaco/domain/weather/model/weather.dart';
+import 'package:weaco/presentation/ootd_feed/ootd_card.dart';
+
+class OotdFeedViewModel extends ChangeNotifier {
+  List<OotdCard> _feedList = [];
+  List<OotdCard> get feedList => List.unmodifiable(_feedList);
+
+
+  OotdFeedViewModel() {
+    loadMorePage();
+  }
+
+  void loadMorePage() {
+    for (int i = 0; i < 5; i++) {
+      _feedList.add(OotdCard(
+          data: Feed(
+              id: '${_feedList.length}',
+              imagePath:
+                  'https://user-images.githubusercontent.com/38002959/143966223-7c10b010-32a9-4fd5-b021-3a9764134318.png',
+              userEmail: 'hoogom87@gmail.com',
+              description: '겨울에는 역시 롱패딩',
+              weather: Weather(
+                  temperature: -10.2,
+                  timeTemperature: DateTime.now(),
+                  code: 0,
+                  createdAt: DateTime.now()),
+              seasonCode: 1,
+              location: Location(
+                  lat: 36.984, lng: 128.546, city: '서울시 노원구', createdAt: DateTime.now()),
+              createdAt: DateTime.now())));
+    }
+    notifyListeners();
+  }
+}


### PR DESCRIPTION
## :: 최근 작업 주제 (하나 이상의 주제를 선택해주세요.)
- [X] 기능 추가
- [ ] 리뷰 반영
- [ ] 리팩토링
- [ ] 버그 수정
- [ ] 컨벤션 수정

<br />

## :: 구현 목표 (해당 브랜치에서 구현하고자 하는 하나의 목표를 설정합니다.)
- OOTD 피드화면 UI 구현

<br />

## :: 구현 사항 설명 (작업한 내용을 상세하게 기록합니다.)
1. OOTD 카드 위젯 구현
위, 아래 플립 애니메이션 처리  
2. OOTD 피드 화면 구현
좌, 우 스와이프로 이동 처리

<br />

## :: 성장 포인트 (해당 기능을 구현하며 고민했던 사항이나 새로 알게된 부분, 어려웠던 점 등을 작성합니다.)
- 한 방향으로만 카드를 뒤지고, 다시 반대로 뒤집는 것은.reverse()를 통해 쉽게 구현이 가능하지만, 위/아래 두 방향 모두 카드를 뒤집고, 같은 방향으로도 계속 카드를 뒤집게 하는 것에서 어려움이 있었습니다. 현재 카드 상태의 앞, 뒤 위젯 변경 로직에, 진행 방향에 따라 시작 위젯(앞/뒤)을 바꿔주는 로직을 추가하여 해결하였습니다.

<br />

## :: 기타 질문 및 특이 사항
- 위젯의 코드는 최적화가 되어 있지 않아, 리팩토링이 필요합니다.
=> 뷰모델까지 구현 후, 리팩토링 할 예정입니다.
