### PR TITLE
Feat/#53 ootd detail UI view model

### DIFF
--- a/lib/core/enum/season_code.dart
+++ b/lib/core/enum/season_code.dart
@@ -1,15 +1,18 @@
 enum SeasonCode {
-  spring(value: 1),
-  summer(value: 2),
-  autumn(value: 3),
-  winter(value: 4);
+  noData(value: 0, description: '-'),
+  spring(value: 1, description: '봄'),
+  summer(value: 2, description: '여름'),
+  autumn(value: 3, description: '가을'),
+  winter(value: 4, description: '겨울');
 
   final int value;
+  final String description;
 
-  const SeasonCode({required this.value});
+  const SeasonCode({required this.value, required this.description});
 
   static SeasonCode fromValue(int value) {
     return switch (value) {
+      0 => SeasonCode.noData,
       1 => SeasonCode.spring,
       2 => SeasonCode.summer,
       3 => SeasonCode.autumn,

--- a/lib/core/enum/weather_code.dart
+++ b/lib/core/enum/weather_code.dart
@@ -77,6 +77,7 @@ enum WeatherCode {
 
   static WeatherCode fromValue(int value) {
     return switch (value) {
+      0 => WeatherCode.noData,
       1 => WeatherCode.clearSky,
       2 => WeatherCode.partlyCloudy,
       3 => WeatherCode.fog,
@@ -90,11 +91,11 @@ enum WeatherCode {
       11 => WeatherCode.snowShower,
       12 => WeatherCode.thunderStorm,
       13 => WeatherCode.thunderStormHail,
-      _ => WeatherCode.noData
+      _ => throw ArgumentError('Invalid value')
     };
   }
 
-  static WeatherCode fromCode(int code) {
+  static WeatherCode fromDtoCode(int code) {
     return switch (code) {
       0 => WeatherCode.clearSky,
       1 || 2 || 3 => WeatherCode.partlyCloudy,
@@ -109,7 +110,7 @@ enum WeatherCode {
       85 || 86 => WeatherCode.snowShower,
       95 => WeatherCode.thunderStorm,
       96 || 99 => WeatherCode.thunderStormHail,
-      _ => throw Exception()
+      _ => throw ArgumentError('Invalid value')
     };
   }
 }

--- a/lib/core/extension/date_time.dart
+++ b/lib/core/extension/date_time.dart
@@ -1,0 +1,6 @@
+extension DateTimeFormat on DateTime {
+  String toFormat() {
+    final midday = hour > 12 ? '오후' : '오전';
+    return '$month월 $day일    $midday ${hour > 12 ? hour - 12 : hour}시 $minute분';
+  }
+}

--- a/lib/core/firebase/firestore_dto_mapper.dart
+++ b/lib/core/firebase/firestore_dto_mapper.dart
@@ -1,20 +1,21 @@
 import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:weaco/domain/feed/model/feed.dart';
 import 'package:weaco/domain/location/model/location.dart';
+import 'package:weaco/domain/user/model/user_profile.dart';
 import 'package:weaco/domain/weather/model/weather.dart';
 
-Feed toFeed({required Map<String, dynamic> feedDto, required String id}) {
+Feed toFeed({required Map<String, dynamic> json, required String id}) {
   return Feed(
     id: id,
-    imagePath: feedDto['image_path'],
-    userEmail: feedDto['user_email'],
-    description: feedDto['description'],
-    weather: Weather.fromJson(feedDto['weather']),
-    seasonCode: feedDto['season_code'],
-    location: Location.fromJson(feedDto['location']),
-    createdAt: (feedDto['created_at'] as Timestamp).toDate(),
-    deletedAt: feedDto['deleted_at'] != null
-        ? (feedDto['deleted_at'] as Timestamp).toDate()
+    imagePath: json['image_path'],
+    userEmail: json['user_email'],
+    description: json['description'],
+    weather: Weather.fromJson(json['weather']),
+    seasonCode: json['season_code'],
+    location: Location.fromJson(json['location']),
+    createdAt: (json['created_at'] as Timestamp).toDate(),
+    deletedAt: json['deleted_at'] != null
+        ? (json['deleted_at'] as Timestamp).toDate()
         : null,
   );
 }
@@ -32,3 +33,34 @@ Map<String, dynamic> toFeedDto({required Feed feed}) {
         feed.deletedAt != null ? Timestamp.fromDate(feed.deletedAt!) : null,
   };
 }
+
+Map<String, dynamic> toUserProfileDto({required UserProfile userProfile}) {
+  return {
+    'email': userProfile.email,
+    'nickname': userProfile.nickname,
+    'gender': userProfile.gender,
+    'profile_image_path': userProfile.profileImagePath,
+    'feed_count': userProfile.feedCount,
+    'created_at': Timestamp.fromDate(userProfile.createdAt),
+    'deleted_at': userProfile.deletedAt != null
+        ? Timestamp.fromDate(userProfile.deletedAt!)
+        : null,
+  };
+}
+
+UserProfile toUserProfile({required Map<String, dynamic> json}) {
+  return UserProfile(
+    email: json['email'],
+    nickname: json['nickname'],
+    gender: json['gender'],
+    profileImagePath: json['profile_image_path'],
+    feedCount: json['feed_count'],
+    createdAt: (json['created_at'] as Timestamp).toDate(),
+    deletedAt: json['deleted_at'] != null
+        ? (json['deleted_at'] as Timestamp).toDate()
+        : null,
+  );
+}
+
+
+

--- a/lib/core/go_router/router.dart
+++ b/lib/core/go_router/router.dart
@@ -1,5 +1,6 @@
 import 'package:go_router/go_router.dart';
 import 'package:provider/provider.dart';
+import 'package:weaco/core/di/di_setup.dart';
 import 'package:weaco/core/enum/router_path.dart';
 import 'package:weaco/main.dart';
 import 'package:weaco/presentation/sign_up/screen/sign_up_screen.dart';
@@ -9,6 +10,7 @@ import 'package:weaco/presentation/home/view_model/home_screen_view_model.dart';
 import 'package:weaco/presentation/ootd_feed_detail/view/ootd_feed_detail.dart';
 import 'package:weaco/presentation/ootd_post/camera_screen.dart';
 import 'package:weaco/presentation/ootd_post/camera_view_model.dart';
+import 'package:weaco/presentation/ootd_feed_detail/view_model/ootd_detail_view_model.dart';
 
 final router = GoRouter(
   initialLocation: '/',
@@ -81,9 +83,12 @@ final router = GoRouter(
     ),
     GoRoute(
       path: RouterPath.ootdDetail.path,
-      builder: (context, state) => const OotdDetailScreen(
-        id: 'asdfasdfsaf',
-      ),
+      builder: (context, state) {
+        return ChangeNotifierProvider(
+          create: (_) => OotdDetailViewModel(getDetailFeedDetailUseCase: getIt(), getUserProfileUseCase: getIt(), id: state.extra as String),
+          child: OotdDetailScreen(),
+        );
+      },
     ),
     GoRoute(
       path: RouterPath.camera.path,

--- a/lib/core/go_router/router_static.dart
+++ b/lib/core/go_router/router_static.dart
@@ -43,8 +43,8 @@ class RouterStatic {
     router.push(RouterPath.ootdFeed.path);
   }
 
-  static void goToOotdDetail(BuildContext context) {
-    router.push(RouterPath.ootdDetail.path);
+  static void goToOotdDetail(BuildContext context, String id) {
+    router.push(RouterPath.ootdDetail.path, extra: id);
   }
 
   static void goToCamera(BuildContext context) {

--- a/lib/data/feed/data_source/remote_feed_data_source_impl.dart
+++ b/lib/data/feed/data_source/remote_feed_data_source_impl.dart
@@ -46,7 +46,7 @@ class RemoteFeedDataSourceImpl implements RemoteFeedDataSource {
       );
     }
 
-    return toFeed(feedDto: docSnapshot.data()!, id: docSnapshot.id);
+    return toFeed(json: docSnapshot.data()!, id: docSnapshot.id);
   }
 
   /// [유저 페이지/마이 페이지]:
@@ -68,7 +68,7 @@ class RemoteFeedDataSourceImpl implements RemoteFeedDataSource {
         .get();
 
     return querySnapshot.docs
-        .map((doc) => toFeed(feedDto: doc.data(), id: doc.id))
+        .map((doc) => toFeed(json: doc.data(), id: doc.id))
         .toList();
   }
 
@@ -106,7 +106,7 @@ class RemoteFeedDataSourceImpl implements RemoteFeedDataSource {
         .get();
 
     return querySnapshot.docs
-        .map((doc) => toFeed(feedDto: doc.data(), id: doc.id))
+        .map((doc) => toFeed(json: doc.data(), id: doc.id))
         .toList();
   }
 
@@ -154,7 +154,7 @@ class RemoteFeedDataSourceImpl implements RemoteFeedDataSource {
         .get();
 
     return querySnapshot.docs
-        .map((doc) => toFeed(feedDto: doc.data(), id: doc.id))
+        .map((doc) => toFeed(json: doc.data(), id: doc.id))
         .toList();
   }
 }

--- a/lib/data/user/data_source/remote_user_profile_date_source_impl.dart
+++ b/lib/data/user/data_source/remote_user_profile_date_source_impl.dart
@@ -1,5 +1,6 @@
 import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:weaco/core/firebase/firebase_auth_service.dart';
+import 'package:weaco/core/firebase/firestore_dto_mapper.dart';
 import 'package:weaco/data/user/data_source/remote_user_profile_data_source.dart';
 import 'package:weaco/domain/user/model/user_profile.dart';
 
@@ -30,22 +31,18 @@ class RemoteUserProfileDataSourceImpl implements RemoteUserProfileDataSource {
 
   @override
   Future<UserProfile> getUserProfile({String? email}) async {
-    try {
-      email = email ?? _firebaseService.firebaseAuth.currentUser!.email;
+    email = email ?? _firebaseService.firebaseAuth.currentUser!.email;
 
-      QuerySnapshot<Map<String, dynamic>> snapshot = await _firestore
-          .collection('user_profiles')
-          .where('email', isEqualTo: email)
-          .get();
+    QuerySnapshot<Map<String, dynamic>> snapshot = await _firestore
+        .collection('user_profiles')
+        .where('email', isEqualTo: email)
+        .get();
 
-      if (snapshot.docs.isEmpty) {
-        throw Exception('유저 프로필이 존재하지 않습니다.');
-      }
-
-      return UserProfile.fromJson(snapshot.docs[0].data());
-    } catch (e) {
-      throw Exception(e);
+    if (snapshot.docs.isEmpty) {
+      throw Exception('유저 프로필이 존재하지 않습니다.');
     }
+
+    return toUserProfile(json: snapshot.docs[0].data());
   }
 
   @override
@@ -59,7 +56,7 @@ class RemoteUserProfileDataSourceImpl implements RemoteUserProfileDataSource {
       return await _firestore
           .collection('user_profiles')
           .doc(originProfileDocument.docs[0].reference.id)
-          .set(userProfile.toJson())
+          .set(toUserProfileDto(userProfile: userProfile))
           .then((value) => true)
           .catchError(
             (e) => false,

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -109,7 +109,7 @@ class _MyHomePageState extends State<MyHomePage> {
               child: const Text('Go to OotdFeedScreen'),
             ),
             TextButton(
-              onPressed: () => RouterStatic.goToOotdDetail(context),
+              onPressed: () => RouterStatic.goToOotdDetail(context, '01tRXEDSFm5HtJwRtZZB'),
               child: const Text('Go to OotdDetailScreen'),
             ),
             TextButton(

--- a/lib/presentation/home/screen/home_screen.dart
+++ b/lib/presentation/home/screen/home_screen.dart
@@ -2,7 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:intl/intl.dart';
 import 'package:provider/provider.dart';
 import 'package:weaco/common/image_path.dart';
-import 'package:weaco/domain/common/enum/weather_code.dart';
+import 'package:weaco/core/enum/weather_code.dart';
 import 'package:weaco/presentation/home/view_model/home_screen_view_model.dart';
 
 /// [홈 화면]
@@ -185,7 +185,7 @@ class _HomeScreenState extends State<HomeScreen> {
                                 ),
                                 const SizedBox(height: 4),
                                 Image.asset(
-                                  WeatherCode.fromCode(dailyLocationWeather
+                                  WeatherCode.fromDtoCode(dailyLocationWeather
                                           .weatherList[index].code)
                                       .iconPath,
                                   width: 28,

--- a/lib/presentation/ootd_feed/view/flip_card.dart
+++ b/lib/presentation/ootd_feed/view/flip_card.dart
@@ -1,6 +1,5 @@
 import 'dart:math';
 import 'package:flutter/material.dart';
-import 'package:weaco/core/go_router/router_static.dart';
 import 'package:weaco/presentation/ootd_feed/ootd_card.dart';
 
 import 'ootd_feed_screen.dart';
@@ -83,7 +82,7 @@ class _FlipCardState extends State<FlipCard>
   Widget build(BuildContext context) {
     return GestureDetector(
       onTap: () {
-        RouterStatic.goToOotdDetail(context);
+        // RouterStatic.goToOotdDetail(context);
       },
       onHorizontalDragStart: (details) {
         _swipeStartPoint = details.localPosition.dx;

--- a/lib/presentation/ootd_feed_detail/view/ootd_feed_detail.dart
+++ b/lib/presentation/ootd_feed_detail/view/ootd_feed_detail.dart
@@ -1,11 +1,15 @@
+import 'dart:developer';
 import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
+import 'package:provider/provider.dart';
+import 'package:weaco/core/enum/season_code.dart';
+import 'package:weaco/core/enum/weather_code.dart';
+import 'package:weaco/core/extension/date_time.dart';
 import 'package:weaco/presentation/ootd_feed_detail/view/pinch_zoom.dart';
+import 'package:weaco/presentation/ootd_feed_detail/view_model/ootd_detail_view_model.dart';
 
 class OotdDetailScreen extends StatefulWidget {
-  final String _id;
-
-  const OotdDetailScreen({super.key, required String id}) : _id = id;
+  const OotdDetailScreen({super.key});
 
   @override
   State<OotdDetailScreen> createState() => _OotdDetailScreenState();
@@ -19,28 +23,60 @@ class _OotdDetailScreenState extends State<OotdDetailScreen> {
     setState(() => _isCancelAreaShow = !_isCancelAreaShow);
   }
 
+  final defaultWidget = Container(
+    decoration: BoxDecoration(
+      gradient: LinearGradient(
+        begin: Alignment.topLeft,
+        end: Alignment.bottomRight,
+        colors: [
+          Colors.grey[300]!,
+          Colors.grey[200]!,
+        ],
+      ),
+    ),
+  );
+
+  Widget _loadingImageWidget({required String? data}) {
+    return Builder(
+      builder: (context) {
+        if (data != null) {
+          return Image.network(
+            data,
+            fit: BoxFit.fitHeight,
+            errorBuilder: (context, error, stackTrace) => defaultWidget,
+          );
+        } else {
+          return defaultWidget;
+        }
+      },
+    );
+  }
+
   @override
   Widget build(BuildContext context) {
+    log('build() 호출');
     return SafeArea(
         child: Stack(
       fit: StackFit.expand,
       alignment: Alignment.bottomCenter,
       children: [
-        PinchZoom(
-          child: Image.network(
-            'https://user-images.githubusercontent.com/38002959/143966223-7c10b010-32a9-4fd5-b021-3a9764134318.png',
-            fit: BoxFit.fitHeight,
-          ),
-        ),
+        Builder(builder: (context) {
+          return PinchZoom(
+            child: _loadingImageWidget(
+                data: context.watch<OotdDetailViewModel>().feed?.imagePath),
+          );
+        }),
         GestureDetector(
           onTap: _changeArea,
           child: Visibility(
             visible: _isCancelAreaShow,
             maintainSize: false,
-            child: Container(
-              width: MediaQuery.of(context).size.width,
-              color: const Color(0x00ffffff),
-            ),
+            child: Builder(builder: (context) {
+              return Container(
+                width: MediaQuery.of(context).size.width,
+                color: const Color(0x00ffffff),
+              );
+            }),
           ),
         ),
         Positioned(
@@ -61,130 +97,159 @@ class _OotdDetailScreenState extends State<OotdDetailScreen> {
                       topLeft: Radius.circular(10),
                       topRight: Radius.circular(10)),
                   color: Color(0x87000000),
-                  boxShadow: [
-                    BoxShadow(
-                      color: Colors.black26,
-                      blurRadius: 10.0, // 얼마나 흩어져
-                      spreadRadius: 0.1, // 얼마나 두껍게
-                    )
-                  ],
                 ),
                 child: Padding(
                   padding:
-                      const EdgeInsets.symmetric(vertical: 24, horizontal: 18),
-                  child: Column(
-                    children: [
-                      Row(
-                        children: [
-                          SizedBox(
-                            width: 20,
-                            height: 20,
-                            child: Image.network(
-                              'https://cdn-icons-png.flaticon.com/256/169/169367.png',
-                              fit: BoxFit.fill,
+                      const EdgeInsets.symmetric(vertical: 18, horizontal: 18),
+                  child: Builder(builder: (context) {
+                    log('하단 시트 build() 호출');
+                    return Column(
+                      children: [
+                        Row(
+                          crossAxisAlignment: CrossAxisAlignment.end,
+                          textBaseline: TextBaseline.ideographic,
+                          children: [
+                            SizedBox(
+                              width: 25,
+                              height: 25,
+                              child: Image.asset(
+                                  WeatherCode.fromValue(context
+                                              .watch<OotdDetailViewModel>()
+                                              .feed
+                                              ?.weather
+                                              .code ??
+                                          0)
+                                      .iconPath,
+                                  errorBuilder: (_, __, ___) => defaultWidget),
                             ),
-                          ),
-                          const SizedBox(
-                            width: 8,
-                          ),
-                          const DefaultTextStyle(
-                            style: TextStyle(
-                                fontSize: 16,
-                                fontWeight: FontWeight.w800,
-                                color: Colors.white),
-                            child: Text('기온 25.5'),
-                          ),
-                          const Spacer(),
-                          const DefaultTextStyle(
-                            style: TextStyle(
-                                fontSize: 16,
-                                fontWeight: FontWeight.w800,
-                                color: Colors.white),
-                            child: Text('2023.04.27'),
-                          ),
-                          const SizedBox(
-                            width: 16,
-                          ),
-                          const Icon(
-                            Icons.edit,
-                            size: 20,
-                            color: Colors.white,
-                          )
-                        ],
-                      ),
-                      const SizedBox(
-                        height: 16,
-                      ),
-                      Row(
-                        children: [
-                          Container(
-                            decoration: BoxDecoration(
-                                borderRadius: BorderRadius.circular(30),
-                                color: const Color(0x33FFFFFF),
-                                border:
-                                    Border.all(color: Colors.white, width: 1)),
-                            child: const Padding(
-                              padding: EdgeInsets.symmetric(
-                                  horizontal: 8, vertical: 4),
-                              child: DefaultTextStyle(
-                                style: TextStyle(
-                                    fontSize: 12,
-                                    fontWeight: FontWeight.normal,
-                                    color: Colors.white),
-                                child: Text('#봄'),
-                              ),
+                            const SizedBox(
+                              width: 8,
                             ),
-                          ),
-                          const SizedBox(
-                            width: 8,
-                          ),
-                          Container(
-                            decoration: BoxDecoration(
-                                borderRadius: BorderRadius.circular(30),
-                                color: const Color(0x33FFFFFF),
-                                border:
-                                    Border.all(color: Colors.white, width: 1)),
-                            child: const Padding(
-                              padding: EdgeInsets.symmetric(
-                                  horizontal: 8, vertical: 4),
-                              child: DefaultTextStyle(
-                                style: TextStyle(
-                                    fontSize: 12,
-                                    fontWeight: FontWeight.normal,
-                                    color: Colors.white),
-                                child: Text('#맑음'),
-                              ),
-                            ),
-                          ),
-                        ],
-                      ),
-                      const SizedBox(
-                        height: 16,
-                      ),
-                      SizedBox(
-                        height: _isCancelAreaShow ? 274 : null,
-                        child: SingleChildScrollView(
-                          scrollDirection: Axis.vertical,
-                          child: Align(
-                            alignment: Alignment.topLeft,
-                            child: DefaultTextStyle(
+                            DefaultTextStyle(
                               style: const TextStyle(
-                                  fontSize: 14,
-                                  fontWeight: FontWeight.normal,
+                                  fontSize: 16,
+                                  fontWeight: FontWeight.w800,
                                   color: Colors.white),
                               child: Text(
-                                '${widget._id}가나다라마바사아자차카타파하\n' * 100,
-                                overflow: _isCancelAreaShow
-                                    ? null
-                                    : TextOverflow.ellipsis,
-                                maxLines: _isCancelAreaShow ? null : 1,
+                                  '${context.watch<OotdDetailViewModel>().feed?.weather.temperature.toString() ?? '--'}°C'),
+                            ),
+                            const Spacer(),
+                            DefaultTextStyle(
+                              style: const TextStyle(
+                                  fontSize: 14,
+                                  fontWeight: FontWeight.w800,
+                                  color: Colors.white),
+                              child: Text(context
+                                      .watch<OotdDetailViewModel>()
+                                      .feed
+                                      ?.createdAt
+                                      .toFormat() ??
+                                  '--'),
+                            ),
+                            Visibility(
+                                maintainSize: false,
+                                visible: context
+                                        .watch<OotdDetailViewModel>()
+                                        .userProfile
+                                        ?.email !=
+                                    context
+                                        .watch<OotdDetailViewModel>()
+                                        .userProfile
+                                        ?.email,
+                                child: const Row(
+                                  children: [
+                                    SizedBox(
+                                      width: 16,
+                                    ),
+                                    Icon(
+                                      Icons.edit,
+                                      size: 20,
+                                      color: Colors.white,
+                                    )
+                                  ],
+                                ))
+                          ],
+                        ),
+                        const SizedBox(
+                          height: 16,
+                        ),
+                        Row(
+                          children: [
+                            Container(
+                              decoration: BoxDecoration(
+                                  borderRadius: BorderRadius.circular(30),
+                                  color: const Color(0x33FFFFFF),
+                                  border: Border.all(
+                                      color: Colors.white, width: 1)),
+                              child: Padding(
+                                padding: const EdgeInsets.symmetric(
+                                    horizontal: 8, vertical: 4),
+                                child: DefaultTextStyle(
+                                  style: const TextStyle(
+                                      fontSize: 12,
+                                      fontWeight: FontWeight.normal,
+                                      color: Colors.white),
+                                  child: Text(
+                                      '#${SeasonCode.fromValue(context.watch<OotdDetailViewModel>().feed?.seasonCode ?? 0).description}'),
+                                ),
+                              ),
+                            ),
+                            const SizedBox(
+                              width: 8,
+                            ),
+                            Container(
+                              decoration: BoxDecoration(
+                                  borderRadius: BorderRadius.circular(30),
+                                  color: const Color(0x33FFFFFF),
+                                  border: Border.all(
+                                      color: Colors.white, width: 1)),
+                              child: Padding(
+                                padding: const EdgeInsets.symmetric(
+                                    horizontal: 8, vertical: 4),
+                                child: DefaultTextStyle(
+                                  style: const TextStyle(
+                                      fontSize: 12,
+                                      fontWeight: FontWeight.normal,
+                                      color: Colors.white),
+                                  child: Text(
+                                      '#${WeatherCode.fromValue(context.watch<OotdDetailViewModel>().feed?.weather.code ?? 0).description}'),
+                                ),
+                              ),
+                            ),
+                          ],
+                        ),
+                        const SizedBox(
+                          height: 24,
+                        ),
+                        SizedBox(
+                          height: _isCancelAreaShow ? 274 : null,
+                          child: SingleChildScrollView(
+                            scrollDirection: Axis.vertical,
+                            child: Align(
+                              alignment: Alignment.topLeft,
+                              child: DefaultTextStyle(
+                                style: const TextStyle(
+                                    fontSize: 14,
+                                    fontWeight: FontWeight.normal,
+                                    color: Colors.white),
+                                child: Text(
+                                  context
+                                          .watch<OotdDetailViewModel>()
+                                          .feed
+                                          ?.description ??
+                                      '--',
+                                  overflow: _isCancelAreaShow
+                                      ? null
+                                      : TextOverflow.ellipsis,
+                                  maxLines: _isCancelAreaShow ? null : 1,
+                                ),
                               ),
                             ),
                           ),
                         ),
-                      ),
-                    ],
-                  ),
+                      ],
+                    );
+                  }),
                 ),
               ),
             ),
@@ -195,41 +260,51 @@ class _OotdDetailScreenState extends State<OotdDetailScreen> {
             width: MediaQuery.of(context).size.width,
             child: Padding(
               padding: const EdgeInsets.fromLTRB(18, 16, 8, 16),
-              child: Row(
-                mainAxisSize: MainAxisSize.max,
-                crossAxisAlignment: CrossAxisAlignment.center,
-                mainAxisAlignment: MainAxisAlignment.start,
-                children: [
-                  ClipRRect(
-                    borderRadius: BorderRadius.circular(30),
-                    child: Image.network(
-                      width: 40,
-                      height: 40,
-                      'https://health.chosun.com/site/data/img_dir/2024/01/22/2024012201607_0.jpg',
-                      fit: BoxFit.fitHeight,
+              child: Builder(builder: (context) {
+                log('상단 프로필 build() 호출');
+                return Row(
+                  mainAxisSize: MainAxisSize.max,
+                  crossAxisAlignment: CrossAxisAlignment.center,
+                  mainAxisAlignment: MainAxisAlignment.start,
+                  children: [
+                    ClipRRect(
+                      borderRadius: BorderRadius.circular(30),
+                      child: SizedBox(
+                        width: 40,
+                        height: 40,
+                        child: _loadingImageWidget(
+                            data: context
+                                .watch<OotdDetailViewModel>()
+                                .userProfile
+                                ?.profileImagePath),
+                      ),
                     ),
-                  ),
-                  const SizedBox(
-                    width: 8,
-                  ),
-                  const DefaultTextStyle(
-                    style: TextStyle(
-                        fontSize: 14,
-                        fontWeight: FontWeight.w700,
-                        color: Colors.white),
-                    child: Text('호구몬_사실 후곰'),
-                  ),
-                  const Spacer(),
-                  IconButton(
-                    icon: const Icon(
-                      Icons.close,
-                      size: 24,
+                    const SizedBox(
+                      width: 8,
                     ),
-                    color: Colors.black,
-                    onPressed: () => context.pop(),
-                  )
-                ],
-              ),
+                    DefaultTextStyle(
+                      style: const TextStyle(
+                          fontSize: 14,
+                          fontWeight: FontWeight.w700,
+                          color: Colors.white),
+                      child: Text(context
+                              .watch<OotdDetailViewModel>()
+                              .feed
+                              ?.userEmail ??
+                          '----'),
+                    ),
+                    const Spacer(),
+                    IconButton(
+                      icon: const Icon(
+                        Icons.close,
+                        size: 24,
+                      ),
+                      color: Colors.black,
+                      onPressed: () => context.pop(),
+                    )
+                  ],
+                );
+              }),
             ))
       ],
     ));

--- a/lib/presentation/ootd_feed_detail/view/pinch_zoom.dart
+++ b/lib/presentation/ootd_feed_detail/view/pinch_zoom.dart
@@ -1,4 +1,5 @@
 import 'dart:async';
+import 'dart:developer';
 import 'package:flutter/material.dart';
 
 class PinchZoom extends StatefulWidget {
@@ -25,6 +26,7 @@ class _PinchZoomState extends State<PinchZoom>
 
   @override
   Widget build(BuildContext context) {
+    log('핀치 줌 이미지 build() 호출');
     return InteractiveViewer(
       key: widgetKey,
       maxScale: 3.0,

--- a/lib/presentation/ootd_feed_detail/view_model/ootd_detail_view_model.dart
+++ b/lib/presentation/ootd_feed_detail/view_model/ootd_detail_view_model.dart
@@ -1,0 +1,33 @@
+import 'package:flutter/material.dart';
+import 'package:weaco/domain/feed/model/feed.dart';
+import 'package:weaco/domain/feed/use_case/get_detail_feed_detail_use_case.dart';
+import 'package:weaco/domain/user/model/user_profile.dart';
+import 'package:weaco/domain/user/use_case/get_user_profile_use_case.dart';
+
+class OotdDetailViewModel extends ChangeNotifier {
+  Feed? _feed;
+  UserProfile? _userProfile;
+
+  UserProfile? get userProfile => _userProfile;
+
+  Feed? get feed => _feed;
+
+  final GetDetailFeedDetailUseCase _getDetailFeedDetailUseCase;
+  final GetUserProfileUseCase _getUserProfileUseCase;
+
+  OotdDetailViewModel(
+      {required GetDetailFeedDetailUseCase getDetailFeedDetailUseCase,
+      required GetUserProfileUseCase getUserProfileUseCase,
+      required String id})
+      : _getDetailFeedDetailUseCase = getDetailFeedDetailUseCase,
+        _getUserProfileUseCase = getUserProfileUseCase {
+    _getFeedDetail(id: id);
+  }
+
+  Future<void> _getFeedDetail({required String id}) async {
+    _feed = (await _getDetailFeedDetailUseCase.execute(id: id)) ??
+        (throw Exception());
+    _userProfile = (await _getUserProfileUseCase.execute(email: _feed!.userEmail));
+    notifyListeners();
+  }
+}

--- a/test/data/feed/data_source/remote_feed_data_source_impl_test.dart
+++ b/test/data/feed/data_source/remote_feed_data_source_impl_test.dart
@@ -208,7 +208,7 @@ void main() {
               await fakeFirestore.collection('feeds').doc(testId).get();
 
           final feedDeletedAt =
-              toFeed(feedDto: docResult.data()!, id: docResult.id).deletedAt;
+              toFeed(json: docResult.data()!, id: docResult.id).deletedAt;
 
           // Then
           expect(result, feedDeletedAt != null);

--- a/test/domain/user/data_source/remote_user_profile_data_source_test.dart
+++ b/test/domain/user/data_source/remote_user_profile_data_source_test.dart
@@ -44,7 +44,7 @@ void main() async {
           () async {
         // Given
         await instance.collection('user_profiles').add({
-          'created_at': '2024-05-01 13:27:00',
+          'created_at': DateTime.parse('2024-05-01 13:27:00'),
           'deleted_at': null,
           'email': 'hoogom87@gmail.com',
           'feed_count': 0,
@@ -78,7 +78,7 @@ void main() async {
         () async {
           // Given
           await instance.collection('user_profiles').add({
-            'created_at': '2024-05-08 02:27:00',
+            'created_at': DateTime.parse('2024-05-08 02:27:00'),
             'deleted_at': null,
             'email': firebaseService.user.email,
             'feed_count': 0,


### PR DESCRIPTION
## :: 최근 작업 주제 (하나 이상의 주제를 선택해주세요.)
- [X] 기능 추가
- [ ] 리뷰 반영
- [X] 리팩토링
- [ㅌ] 버그 수정
- [ ] 컨벤션 수정

<br />

## :: 구현 목표 (해당 브랜치에서 구현하고자 하는 하나의 목표를 설정합니다.)
- OotdDetailViewMode 작성
- Ootd 상세 화면 데이터-뷰 연결
- Firestore user_profiles 데이터 요청, 추가 관련 오류 해결

<br />

## :: 구현 사항 설명 (작업한 내용을 상세하게 기록합니다.)
1. OotdDetailViewModel 작성
2. UserProfile 모델 <-> 파이어베이스 관련 직렬화/역직렬화 메서드 대체
3. OOTD 상세 화면 위젯 빌드 최적화

<br />

## :: 성장 포인트 (해당 기능을 구현하며 고민했던 사항이나 새로 알게된 부분, 어려웠던 점 등을 작성합니다.)
- 위젯에 필요한 데이터의 상태(초기, 요청 중, 갱신, 에러)에 따른 처리를 위해 분기 처리 로직을 구현하는 것이 어려웠습니다.
=> 특히 이미지에서 데이터의 상태가 복잡하여 별도의 위젯으로 분리하여 처리하였습니다.

- 위젯 빌드 최적화를 위해, 위젯이 관찰하고 있는 데이터 별로 각각 빌드되도록 context를 분리하였습니다.


<br />

## :: 기타 질문 및 특이 사항
- fake 객체를 통해 파이어베이스 관련 코드를 테스트하였지만, 실제 동작에서 오류가 발생하고 있습니다. 
=> UserProfile 직렬화/역직렬화 메서드를 수정하여 오류를 해결하였습니다.
=> 기존의 FirestoreDtoMapper에 메서드가 추가됨에 따라, 해당 객체(정확히는 파일)의 책임과 경계가 모호해지고 있습니다.

