### PR TITLE
Feat/#49 picture crop screen UI viewmodel

### DIFF
--- a/lib/core/di/di_setup.dart
+++ b/lib/core/di/di_setup.dart
@@ -5,6 +5,9 @@ import 'package:weaco/core/di/file/file_di_setup.dart';
 import 'package:weaco/core/di/location/location_di_setup.dart';
 import 'package:weaco/core/di/user/user_di_setup.dart';
 import 'package:weaco/core/di/weather/weather_di_setup.dart';
+import 'package:weaco/domain/file/use_case/save_image_use_case.dart';
+import 'package:weaco/domain/file/use_case/get_image_use_case.dart';
+import 'package:weaco/presentation/ootd_post/picture_crop/picutre_crop_view_model.dart';
 
 final getIt = GetIt.instance;
 
@@ -25,7 +28,13 @@ void diSetup() {
   locationDiSetup();
   feedDiSetup();
   weatherDiSetup();
-  // ViewModel
 
+  // ViewModel
+  getIt.registerFactory<PictureCropViewModel>(
+    () => PictureCropViewModel(
+      saveImageUseCase: getIt<SaveImageUseCase>(),
+      getImageUseCase: getIt<GetImageUseCase>(),
+    ),
+  );
   // View
 }

--- a/lib/core/di/di_setup.dart
+++ b/lib/core/di/di_setup.dart
@@ -6,7 +6,6 @@ import 'package:weaco/core/di/location/location_di_setup.dart';
 import 'package:weaco/core/di/user/user_di_setup.dart';
 import 'package:weaco/core/di/weather/weather_di_setup.dart';
 import 'package:weaco/domain/file/use_case/save_image_use_case.dart';
-import 'package:weaco/domain/file/use_case/get_image_use_case.dart';
 import 'package:weaco/presentation/ootd_post/picture_crop/picutre_crop_view_model.dart';
 
 final getIt = GetIt.instance;
@@ -31,10 +30,7 @@ void diSetup() {
 
   // ViewModel
   getIt.registerFactory<PictureCropViewModel>(
-    () => PictureCropViewModel(
-      saveImageUseCase: getIt<SaveImageUseCase>(),
-      getImageUseCase: getIt<GetImageUseCase>(),
-    ),
+    () => PictureCropViewModel(saveImageUseCase: getIt<SaveImageUseCase>()),
   );
   // View
 }

--- a/lib/core/go_router/router.dart
+++ b/lib/core/go_router/router.dart
@@ -1,7 +1,9 @@
 import 'package:go_router/go_router.dart';
 import 'package:provider/provider.dart';
+import 'package:weaco/core/di/di_setup.dart';
 import 'package:weaco/core/enum/router_path.dart';
 import 'package:weaco/main.dart';
+import 'package:weaco/presentation/ootd_post/picture_crop/picutre_crop_view_model.dart';
 import 'package:weaco/presentation/sign_up/screen/sign_up_screen.dart';
 import 'package:weaco/presentation/sign_in/screen/sign_in_screen.dart';
 import 'package:weaco/presentation/home/screen/home_screen.dart';
@@ -98,7 +100,12 @@ final router = GoRouter(
     ),
     GoRoute(
       path: RouterPath.pictureCrop.path,
-      builder: (context, state) => const PictureCropScreen(),
+      builder: (context, state) {
+        return ChangeNotifierProvider(
+          create: (_) => getIt<PictureCropViewModel>(),
+          child: const PictureCropScreen(),
+        );
+      },
     ),
     GoRoute(
       path: RouterPath.ootdPost.path,

--- a/lib/presentation/ootd_post/picture_crop/picture_crop_screen.dart
+++ b/lib/presentation/ootd_post/picture_crop/picture_crop_screen.dart
@@ -19,7 +19,7 @@ class _PictureCropScreenState extends State<PictureCropScreen> {
     return Scaffold(
       appBar: AppBar(
         leading: IconButton(
-          onPressed: () => context.pop,
+          onPressed: () => context.pop(),
           icon: const Icon(Icons.arrow_back),
         ),
         actions: [

--- a/lib/presentation/ootd_post/picture_crop/picture_crop_screen.dart
+++ b/lib/presentation/ootd_post/picture_crop/picture_crop_screen.dart
@@ -1,10 +1,9 @@
 import 'dart:io';
 
 import 'package:flutter/material.dart';
-import 'package:go_router/go_router.dart';
 import 'package:image_cropper/image_cropper.dart';
 import 'package:provider/provider.dart';
-import 'package:weaco/core/enum/router_path.dart';
+import 'package:weaco/core/go_router/router_static.dart';
 import 'package:weaco/presentation/ootd_post/picture_crop/picutre_crop_view_model.dart';
 
 class PictureCropScreen extends StatefulWidget {
@@ -15,7 +14,6 @@ class PictureCropScreen extends StatefulWidget {
 }
 
 class _PictureCropScreenState extends State<PictureCropScreen> {
-  late Future<void> _cropImageFuture;
   CroppedFile? _croppedFile;
   final String samplePath =
       '/data/data/team.weather.weaco/cache/0ddabc12-9269-428b-8123-b09d1230c5a62983180504067444417.jpg';
@@ -23,26 +21,12 @@ class _PictureCropScreenState extends State<PictureCropScreen> {
   @override
   void initState() {
     super.initState();
-    _cropImageFuture = _cropImage(samplePath);
+    _cropImage(samplePath);
   }
 
   @override
   Widget build(BuildContext context) {
-    final viewModel = context.watch<PictureCropViewModel>();
-
-    return FutureBuilder(
-      future: _cropImageFuture,
-      builder: (context, snapshot) {
-        if (snapshot.connectionState == ConnectionState.waiting) {
-          return const Center(child: CircularProgressIndicator());
-        } else {
-          _cropResult(samplePath, viewModel);
-          return const Scaffold(
-            body: SizedBox(),
-          );
-        }
-      },
-    );
+    return const Scaffold();
   }
 
   Future<void> _cropImage(String samplePath) async {
@@ -67,29 +51,33 @@ class _PictureCropScreenState extends State<PictureCropScreen> {
 
     if (croppedFile != null) {
       _croppedFile = croppedFile;
+
+      _cropResult(samplePath);
     }
   }
 
-  void _cropResult(String samplePath, PictureCropViewModel viewModel) {
+  void _cropResult(String samplePath) async {
+    final PictureCropViewModel viewModel = context.read<PictureCropViewModel>();
     if (_croppedFile == null) {
       return;
     } else {
-      viewModel.saveOriginImage(file: File(samplePath));
+      await viewModel.saveOriginImage(file: File(samplePath));
 
-      viewModel.saveCroppedImage(
-        file: File(_croppedFile!.path),
-        callback: (result) {
-          if (result) {
-            context.push(RouterPath.ootdPost.path);
-          } else {
-            ScaffoldMessenger.of(context).showSnackBar(
-              const SnackBar(
-                content: Text('잠시 후 다시 시도해 주시기 바랍니다.'),
-              ),
-            );
-          }
-        },
-      );
+      await viewModel.saveCroppedImage(file: File(_croppedFile!.path));
+
+      if (viewModel.status.isSuccess) {
+        if (mounted) {
+          RouterStatic.goToOotdPost(context);
+        }
+      } else if (viewModel.status.isError) {
+        if (mounted) {
+          ScaffoldMessenger.of(context).showSnackBar(
+            const SnackBar(
+              content: Text('잠시 후 다시 시도해 주시기 바랍니다.'),
+            ),
+          );
+        }
+      }
     }
   }
 }

--- a/lib/presentation/ootd_post/picture_crop/picture_crop_screen.dart
+++ b/lib/presentation/ootd_post/picture_crop/picture_crop_screen.dart
@@ -3,6 +3,9 @@ import 'dart:io';
 import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
 import 'package:image_cropper/image_cropper.dart';
+import 'package:provider/provider.dart';
+import 'package:weaco/core/enum/router_path.dart';
+import 'package:weaco/presentation/ootd_post/picture_crop/picutre_crop_view_model.dart';
 
 class PictureCropScreen extends StatefulWidget {
   const PictureCropScreen({super.key});
@@ -16,6 +19,8 @@ class _PictureCropScreenState extends State<PictureCropScreen> {
 
   @override
   Widget build(BuildContext context) {
+    final viewModel = context.watch<PictureCropViewModel>();
+
     return Scaffold(
       appBar: AppBar(
         leading: IconButton(
@@ -49,7 +54,7 @@ class _PictureCropScreenState extends State<PictureCropScreen> {
                 : const Text('이미지 없을 무'),
             ElevatedButton(
               onPressed: () async {
-                await cropImage();
+                await cropImage(viewModel);
               },
               child: const Text('이미지 가져오기'),
             ),
@@ -59,7 +64,7 @@ class _PictureCropScreenState extends State<PictureCropScreen> {
     );
   }
 
-  Future<void> cropImage() async {
+  Future<void> cropImage(PictureCropViewModel viewModel) async {
     const String samplePath =
         '/data/user/0/team.weather.weaco/cache/c2b5e982-bdf9-413b-a1c0-06966e6a4683/1000000018.jpg';
     final croppedFile = await ImageCropper().cropImage(
@@ -82,6 +87,21 @@ class _PictureCropScreenState extends State<PictureCropScreen> {
     );
 
     if (croppedFile != null) {
+      viewModel.saveOriginImage(file: File(samplePath));
+      viewModel.saveCroppedImage(
+          file: File(croppedFile.path),
+          callback: (result) {
+            if (result) {
+              context.push(RouterPath.ootdPost.path);
+            } else {
+              ScaffoldMessenger.of(context).showSnackBar(
+                const SnackBar(
+                  content: Text('잠시 후 다시 시도해 주시기 바랍니다.'),
+                ),
+              );
+            }
+          });
+
       setState(() {
         _croppedFile = croppedFile;
       });

--- a/lib/presentation/ootd_post/picture_crop/picutre_crop_view_model.dart
+++ b/lib/presentation/ootd_post/picture_crop/picutre_crop_view_model.dart
@@ -1,19 +1,14 @@
 import 'dart:io';
 
 import 'package:flutter/cupertino.dart';
-import 'package:weaco/domain/file/use_case/get_image_use_case.dart';
 import 'package:weaco/domain/file/use_case/save_image_use_case.dart';
 
 class PictureCropViewModel with ChangeNotifier {
   final SaveImageUseCase _saveImageUseCase;
-  final GetImageUseCase _getImageUseCase;
-  File? _file;
 
   PictureCropViewModel({
     required SaveImageUseCase saveImageUseCase,
-    required GetImageUseCase getImageUseCase,
-  })  : _saveImageUseCase = saveImageUseCase,
-        _getImageUseCase = getImageUseCase;
+  })  : _saveImageUseCase = saveImageUseCase;
 
   /// 원본 이미지 저장
   void saveOriginImage({required File file}) async {

--- a/lib/presentation/ootd_post/picture_crop/picutre_crop_view_model.dart
+++ b/lib/presentation/ootd_post/picture_crop/picutre_crop_view_model.dart
@@ -1,0 +1,33 @@
+import 'dart:io';
+
+import 'package:flutter/cupertino.dart';
+import 'package:weaco/domain/file/use_case/get_image_use_case.dart';
+import 'package:weaco/domain/file/use_case/save_image_use_case.dart';
+
+class PictureCropViewModel with ChangeNotifier {
+  final SaveImageUseCase _saveImageUseCase;
+  final GetImageUseCase _getImageUseCase;
+  File? _file;
+
+  PictureCropViewModel({
+    required SaveImageUseCase saveImageUseCase,
+    required GetImageUseCase getImageUseCase,
+  })  : _saveImageUseCase = saveImageUseCase,
+        _getImageUseCase = getImageUseCase;
+
+  /// 원본 이미지 저장
+  void saveOriginImage({required File file}) async {
+    await _saveImageUseCase.execute(isOrigin: true, file: file);
+  }
+
+  /// 크롭 이미지 저장
+  void saveCroppedImage({
+    required File file,
+    required Function(bool) callback,
+  }) async {
+    final bool result =
+        await _saveImageUseCase.execute(isOrigin: false, file: file);
+
+    callback(result);
+  }
+}

--- a/lib/presentation/ootd_post/picture_crop/picutre_crop_view_model.dart
+++ b/lib/presentation/ootd_post/picture_crop/picutre_crop_view_model.dart
@@ -3,26 +3,43 @@ import 'dart:io';
 import 'package:flutter/cupertino.dart';
 import 'package:weaco/domain/file/use_case/save_image_use_case.dart';
 
+enum PictureCropSaveStatus {
+  idle,
+  success,
+  error;
+
+  bool get isIdle => this == PictureCropSaveStatus.idle;
+
+  bool get isSuccess => this == PictureCropSaveStatus.success;
+
+  bool get isError => this == PictureCropSaveStatus.error;
+}
+
 class PictureCropViewModel with ChangeNotifier {
   final SaveImageUseCase _saveImageUseCase;
+  PictureCropSaveStatus _status = PictureCropSaveStatus.idle;
 
   PictureCropViewModel({
     required SaveImageUseCase saveImageUseCase,
-  })  : _saveImageUseCase = saveImageUseCase;
+  }) : _saveImageUseCase = saveImageUseCase;
 
   /// 원본 이미지 저장
-  void saveOriginImage({required File file}) async {
+  Future<void> saveOriginImage({required File file}) async {
     await _saveImageUseCase.execute(isOrigin: true, file: file);
   }
 
   /// 크롭 이미지 저장
-  void saveCroppedImage({
-    required File file,
-    required Function(bool) callback,
-  }) async {
+  Future<void> saveCroppedImage({required File file}) async {
     final bool result =
         await _saveImageUseCase.execute(isOrigin: false, file: file);
 
-    callback(result);
+    if (result) {
+      _status = PictureCropSaveStatus.success;
+    } else {
+      _status = PictureCropSaveStatus.error;
+    }
+    notifyListeners();
   }
+
+  PictureCropSaveStatus get status => _status;
 }


### PR DESCRIPTION
## :: 최근 작업 주제 (하나 이상의 주제를 선택해주세요.)
- [x] 기능 추가
- [x] 리뷰 반영
- [ ] 리팩토링
- [ ] 버그 수정
- [ ] 컨벤션 수정

<br />

## :: 구현 목표 (해당 브랜치에서 구현하고자 하는 하나의 목표를 설정합니다.)
- 유저가 이미지 크롭 후 확인 버튼을 누르면, 원본 이미지와 크롭 이미지를 파일에 저장합니다.

<br />

## :: 구현 사항 설명 (작업한 내용을 상세하게 기록합니다.)
1. 기존 코드는 크롭 화면에서 '이미지 가져오기' 버튼을 눌러 크롭 화면을 띄웠습니다.
-> 카메라 또는 갤러리에서 이미지 선택 후 크롭 화면으로 왔을 때, 바로 크롭 화면을 띄워주기 위해 init()에 해당 메서드를 위치시켰습니다.

2. 이미지를 크롭하면 FileRepository.saveImage()에 원본 이미지와 크롭 이미지를 저장합니다.
3. 이미지를 저장하면 다음 화면(OOTD 작성/수정)으로 이동합니다.

<추가 구현>
1. FutureBuilder 제거

2. viewModel에서 데이터 저장에 대한 콜백 메서드 제거
=> viewModel에서 사용되는 메서드에 반환 타입을 주지 않게 구현하려다보니 콜백 메서드를 사용하게 되었습니다.
그런데 이 또한 메모리 참조로 context를 가지고 있어서 뷰가 죽어도 context 참조가 살아있어서 메모리 누수가 발생할 수 있음을 알게 되었습니다.

=> PictureCropSaveStatus enum을 생성하여 상태를 읽어오도록 변경하였습니다.
=> FutureBuilder와 콜백 메서드를 사용하지 않아도 되었습니다.

<br />

## :: 성장 포인트 (해당 기능을 구현하며 고민했던 사항이나 새로 알게된 부분, 어려웠던 점 등을 작성합니다.)
- enum에 대해 학습하였습니다.
- 패턴 흐름에 대해 다시 정리하였습니다.

<br />

## :: 기타 질문 및 특이 사항
