### PR TITLE
Feat/#51 ootd UI viewmodel

### DIFF
--- a/lib/common/image_path.dart
+++ b/lib/common/image_path.dart
@@ -22,7 +22,7 @@ class ImagePath {
 
   static const String weatherRainShower = '$_iconPath/weather_rain_shower_icon.png';
 
-  static const String weatherFreezingRain = '$_iconPath/weather_frezzing_rain_icon.png';
+  static const String weatherFreezingRain = '$_iconPath/weather_freezing_rain_icon.png';
 
   static const String weatherSnow = '$_iconPath/weather_snow_icon.png';
 

--- a/lib/core/di/feed/feed_di_setup.dart
+++ b/lib/core/di/feed/feed_di_setup.dart
@@ -16,6 +16,9 @@ import 'package:weaco/domain/feed/use_case/remove_my_page_feed_use_case.dart';
 import 'package:weaco/domain/feed/use_case/save_edit_feed_use_case.dart';
 import 'package:weaco/domain/file/repository/file_repository.dart';
 import 'package:weaco/domain/user/repository/user_profile_repository.dart';
+import 'package:weaco/domain/user/use_case/get_user_profile_use_case.dart';
+import 'package:weaco/presentation/ootd_feed/view_model/ootd_feed_view_model.dart';
+import 'package:weaco/presentation/ootd_feed_detail/view_model/ootd_detail_view_model.dart';
 
 void feedDiSetup() {
   // DataSource
@@ -47,4 +50,8 @@ void feedDiSetup() {
       RemoveMyPageFeedUseCase(ootdFeedRepository: getIt<OotdFeedRepository>()));
   getIt.registerLazySingleton<SaveEditFeedUseCase>(() =>
       SaveEditFeedUseCase(ootdFeedRepository: getIt<OotdFeedRepository>()));
+  
+  // ViewModel
+  getIt.registerFactory(() => OotdFeedViewModel(getSearchFeedsUseCase: getIt<GetSearchFeedsUseCase>()));
+  getIt.registerFactoryParam((id, _) => OotdDetailViewModel(getDetailFeedDetailUseCase: getIt<GetDetailFeedDetailUseCase>(), getUserProfileUseCase: getIt<GetUserProfileUseCase>(), id: id as String));
 }

--- a/lib/core/go_router/router.dart
+++ b/lib/core/go_router/router.dart
@@ -82,7 +82,7 @@ final router = GoRouter(
       path: RouterPath.ootdFeed.path,
       builder: (context, state) {
         return ChangeNotifierProvider(
-          create: (_) => OotdFeedViewModel(getSearchFeedsUseCase: getIt()),
+          create: (_) => getIt<OotdFeedViewModel>(),
           child: const OotdFeedScreen(),
         );
       },
@@ -91,10 +91,7 @@ final router = GoRouter(
       path: RouterPath.ootdDetail.path,
       builder: (context, state) {
         return ChangeNotifierProvider(
-          create: (_) => OotdDetailViewModel(
-              getDetailFeedDetailUseCase: getIt(),
-              getUserProfileUseCase: getIt(),
-              id: state.uri.queryParameters['id'] ?? ''),
+          create: (_) => getIt<OotdDetailViewModel>(param1: state.uri.queryParameters['id'] ?? ''),
           child: OotdDetailScreen(id: state.uri.queryParameters['id'] ?? '', mainImagePath: state.uri.queryParameters['imagePath'] ?? '',),
         );
       },

--- a/lib/core/go_router/router.dart
+++ b/lib/core/go_router/router.dart
@@ -3,6 +3,8 @@ import 'package:provider/provider.dart';
 import 'package:weaco/core/di/di_setup.dart';
 import 'package:weaco/core/enum/router_path.dart';
 import 'package:weaco/main.dart';
+import 'package:weaco/presentation/ootd_feed/view/ootd_feed_screen.dart';
+import 'package:weaco/presentation/ootd_feed/view_model/ootd_feed_view_model.dart';
 import 'package:weaco/presentation/sign_up/screen/sign_up_screen.dart';
 import 'package:weaco/presentation/sign_in/screen/sign_in_screen.dart';
 import 'package:weaco/presentation/home/screen/home_screen.dart';
@@ -78,17 +80,22 @@ final router = GoRouter(
     ),
     GoRoute(
       path: RouterPath.ootdFeed.path,
-      // builder: (context, state) => OotdFeedScreen(),
-      builder: (context, state) => const MyHomePage(
-        title: '',
-      ),
+      builder: (context, state) {
+        return ChangeNotifierProvider(
+          create: (_) => OotdFeedViewModel(getSearchFeedsUseCase: getIt()),
+          child: const OotdFeedScreen(),
+        );
+      },
     ),
     GoRoute(
       path: RouterPath.ootdDetail.path,
       builder: (context, state) {
         return ChangeNotifierProvider(
-          create: (_) => OotdDetailViewModel(getDetailFeedDetailUseCase: getIt(), getUserProfileUseCase: getIt(), id: state.extra as String),
-          child: const OotdDetailScreen(),
+          create: (_) => OotdDetailViewModel(
+              getDetailFeedDetailUseCase: getIt(),
+              getUserProfileUseCase: getIt(),
+              id: state.uri.queryParameters['id'] ?? ''),
+          child: OotdDetailScreen(id: state.uri.queryParameters['id'] ?? '', mainImagePath: state.uri.queryParameters['imagePath'] ?? '',),
         );
       },
     ),

--- a/lib/core/go_router/router_static.dart
+++ b/lib/core/go_router/router_static.dart
@@ -43,8 +43,8 @@ class RouterStatic {
     router.push(RouterPath.ootdFeed.path);
   }
 
-  static void goToOotdDetail(BuildContext context, String id) {
-    router.push(RouterPath.ootdDetail.path, extra: id);
+  static void goToOotdDetail(BuildContext context, {required String id, required String imagePath}) {
+    router.push('${RouterPath.ootdDetail.path}?id=$id&imagePath=$imagePath');
   }
 
   static void goToCamera(BuildContext context) {

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -105,11 +105,11 @@ class _MyHomePageState extends State<MyHomePage> {
               child: const Text('Go to OotdSearchScreen'),
             ),
             TextButton(
-              onPressed: () {},
+              onPressed: () => RouterStatic.goToOotdFeed(context),
               child: const Text('Go to OotdFeedScreen'),
             ),
             TextButton(
-              onPressed: () => RouterStatic.goToOotdDetail(context, '01tRXEDSFm5HtJwRtZZB'),
+              onPressed: () {  },
               child: const Text('Go to OotdDetailScreen'),
             ),
             TextButton(

--- a/lib/presentation/home/component/recommand_ootd_list_widget.dart
+++ b/lib/presentation/home/component/recommand_ootd_list_widget.dart
@@ -46,7 +46,8 @@ class RecommandOotdListWidget extends StatelessWidget {
                         return GestureDetector(
                           onTap: () => RouterStatic.goToOotdDetail(
                             context,
-                            feedList[index].id!,
+                            id: feedList[index].id ?? '',
+                            imagePath: feedList[index].imagePath,
                           ),
                           child: RecommandOotdWidget(
                             feedList: feedList,

--- a/lib/presentation/ootd_feed/ootd_card.dart
+++ b/lib/presentation/ootd_feed/ootd_card.dart
@@ -1,11 +1,8 @@
 import 'package:weaco/domain/feed/model/feed.dart';
 
 class OotdCard {
-  bool isFront = true;
-  final Feed _feed;
+  bool isFront;
+  final Feed feed;
 
-  OotdCard({required Feed data}) : _feed = data;
-
-
-  Feed get feed => _feed;
+  OotdCard({required this.feed, this.isFront = true});
 }

--- a/lib/presentation/ootd_feed/view/flip_card.dart
+++ b/lib/presentation/ootd_feed/view/flip_card.dart
@@ -198,6 +198,7 @@ class _FlipCardState extends State<FlipCard>
         ),
         boxShadow: const [
           BoxShadow(
+            offset: Offset(0, 5),
             color: Colors.black26,
             blurRadius: 10.0, // 얼마나 흩어져
             spreadRadius: 0.01, // 얼마나 두껍게
@@ -207,7 +208,8 @@ class _FlipCardState extends State<FlipCard>
       child: ClipRRect(
         borderRadius: BorderRadius.circular(30),
         child: Image.network(
-          _data.feed.imagePath,
+          'https://user-images.githubusercontent.com/38002959/143966223-7c10b010-32a9-4fd5-b021-3a9764134318.png',
+          // _data.feed.imagePath,
           fit: BoxFit.fitHeight,
         ),
       ),
@@ -221,6 +223,7 @@ class _FlipCardState extends State<FlipCard>
         color: Colors.white,
         boxShadow: const [
           BoxShadow(
+            offset: Offset(0, 5),
             color: Colors.black12,
             blurRadius: 10.0, // 얼마나 흩어져
             spreadRadius: 0.01, // 얼마나 두껍게
@@ -239,11 +242,11 @@ class _FlipCardState extends State<FlipCard>
                   fontWeight: FontWeight.w800,
                   color: Colors.black),
               child: Text(
-                  '너의 날씨는?'),
+                  '그 날의 날씨는'),
             ),
             SizedBox(
-              width: 80,
-              height: 80,
+              width: 100,
+              height: 100,
               child: Image.asset(
                   WeatherCode.fromValue(_data.feed.weather.code)
                       .iconPath),
@@ -293,7 +296,7 @@ class _FlipCardState extends State<FlipCard>
                           fontWeight: FontWeight.bold,
                           color: Colors.black),
                       child: Text(
-                          '그날의 온도는'),
+                          '이 날의 온도는'),
                     ),
                     DefaultTextStyle(
                       style: const TextStyle(

--- a/lib/presentation/ootd_feed/view/ootd_feed_screen.dart
+++ b/lib/presentation/ootd_feed/view/ootd_feed_screen.dart
@@ -1,12 +1,13 @@
+import 'dart:developer';
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 import 'package:weaco/presentation/ootd_feed/view_model/ootd_feed_view_model.dart';
 import 'flip_card.dart';
 
-double scale = 30;
+double scale = 35;
 double cardWidth = 9 * scale;
 double cardHeight = 16 * scale;
-Duration cardMoveSpeed = const Duration(milliseconds: 200);
+Duration cardMoveSpeed = const Duration(milliseconds: 250);
 
 class OotdFeedScreen extends StatefulWidget {
   const OotdFeedScreen({super.key});
@@ -17,12 +18,11 @@ class OotdFeedScreen extends StatefulWidget {
 
 class _OotdFeedScreenState extends State<OotdFeedScreen> {
   late PageController _pageViewController;
-  int _currentIdx = 0;
 
   @override
   void initState() {
     super.initState();
-    _pageViewController = PageController(viewportFraction: 0.8);
+    _pageViewController = PageController(viewportFraction: 0.75);
   }
 
   @override
@@ -33,42 +33,38 @@ class _OotdFeedScreenState extends State<OotdFeedScreen> {
 
   @override
   Widget build(BuildContext context) {
+    log('전체 build() 호출', name: 'OotdFeedScreen.build()');
     return Scaffold(
-      body: PageView(
-        physics: const NeverScrollableScrollPhysics(),
+      body: PageView.builder(
         controller: _pageViewController,
-        // padEnds: true,
+        physics: const NeverScrollableScrollPhysics(),
         pageSnapping: true,
-        children: List.generate(
-           context.watch<OotdFeedViewModel>().feedList.length,
-            (index) => Center(
-                  child: SizedBox(
-                    width: cardWidth,
-                    height: cardHeight,
-                    child: FlipCard(data: context.watch<OotdFeedViewModel>().feedList[index], moveCallback: moveCard, flipCallback: flipCard),
-                  ),
-                )),
+        itemCount: context.watch<OotdFeedViewModel>().feedList.length,
+        itemBuilder: (BuildContext context, int index) {
+          return Center(
+            child: SizedBox(
+              width: cardWidth,
+              height: cardHeight,
+              child: FlipCard(
+                  index: index, moveCallback: moveCard, flipCallback: flipCard),
+            ),
+          );
+        },
       ),
     );
   }
 
   void moveCard({required bool isToNext}) {
-    int currentLength = context.read<OotdFeedViewModel>().feedList.length;
-    isToNext ? _currentIdx++ : _currentIdx--;
-    if (_currentIdx < 0) _currentIdx = 0;
-    if (_currentIdx + 2 == currentLength) {
-      context.read<OotdFeedViewModel>().loadMorePage();
-    }
-    if (_currentIdx >= currentLength) _currentIdx = currentLength - 1;
-
+    final nextIndex =
+        context.read<OotdFeedViewModel>().moveIndex(isToNext: isToNext);
     _pageViewController.animateToPage(
-      _currentIdx,
+      nextIndex,
       duration: cardMoveSpeed,
       curve: Curves.easeInOut,
     );
   }
 
   void flipCard() {
-    // context.read<OotdFeedViewModel>().flipCard(index: _currentIdx);
+    context.read<OotdFeedViewModel>().flipCard();
   }
 }

--- a/lib/presentation/ootd_feed_detail/view/ootd_feed_detail.dart
+++ b/lib/presentation/ootd_feed_detail/view/ootd_feed_detail.dart
@@ -1,5 +1,6 @@
 import 'dart:developer';
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:go_router/go_router.dart';
 import 'package:provider/provider.dart';
 import 'package:weaco/core/enum/season_code.dart';
@@ -24,6 +25,13 @@ class OotdDetailScreen extends StatefulWidget {
 class _OotdDetailScreenState extends State<OotdDetailScreen> {
   final double _detailAreaExpandHeight = 400;
   bool _isCancelAreaShow = false;
+
+
+  @override
+  void initState() {
+    super.initState();
+    SystemChrome.setSystemUIOverlayStyle(SystemUiOverlayStyle.light);
+  }
 
   void _changeArea() {
     setState(() => _isCancelAreaShow = !_isCancelAreaShow);
@@ -265,7 +273,7 @@ class _OotdDetailScreenState extends State<OotdDetailScreen> {
             top: 0,
             width: MediaQuery.of(context).size.width,
             child: Padding(
-              padding: const EdgeInsets.fromLTRB(18, 10, 8, 0),
+              padding: const EdgeInsets.fromLTRB(18, 16, 8, 0),
               child: Builder(builder: (context) {
                 log('상단 프로필 build() 호출');
                 return Row(
@@ -304,7 +312,7 @@ class _OotdDetailScreenState extends State<OotdDetailScreen> {
                     IconButton(
                       icon: const Icon(
                         Icons.close,
-                        size: 24,
+                        size: 28,
                       ),
                       color: Colors.white,
                       onPressed: () => context.pop(),

--- a/lib/presentation/ootd_feed_detail/view/ootd_feed_detail.dart
+++ b/lib/presentation/ootd_feed_detail/view/ootd_feed_detail.dart
@@ -265,7 +265,7 @@ class _OotdDetailScreenState extends State<OotdDetailScreen> {
             top: 0,
             width: MediaQuery.of(context).size.width,
             child: Padding(
-              padding: const EdgeInsets.fromLTRB(18, 16, 8, 16),
+              padding: const EdgeInsets.fromLTRB(18, 10, 8, 0),
               child: Builder(builder: (context) {
                 log('상단 프로필 build() 호출');
                 return Row(

--- a/lib/presentation/ootd_feed_detail/view/ootd_feed_detail.dart
+++ b/lib/presentation/ootd_feed_detail/view/ootd_feed_detail.dart
@@ -9,7 +9,13 @@ import 'package:weaco/presentation/ootd_feed_detail/view/pinch_zoom.dart';
 import 'package:weaco/presentation/ootd_feed_detail/view_model/ootd_detail_view_model.dart';
 
 class OotdDetailScreen extends StatefulWidget {
-  const OotdDetailScreen({super.key});
+  final String _id;
+  final String _mainImagePath;
+
+  const OotdDetailScreen(
+      {super.key, required String id, required String mainImagePath})
+      : _mainImagePath = mainImagePath,
+        _id = id;
 
   @override
   State<OotdDetailScreen> createState() => _OotdDetailScreenState();
@@ -23,30 +29,31 @@ class _OotdDetailScreenState extends State<OotdDetailScreen> {
     setState(() => _isCancelAreaShow = !_isCancelAreaShow);
   }
 
-  final defaultWidget = Container(
-    decoration: BoxDecoration(
-      gradient: LinearGradient(
-        begin: Alignment.topLeft,
-        end: Alignment.bottomRight,
-        colors: [
-          Colors.grey[300]!,
-          Colors.grey[200]!,
-        ],
-      ),
-    ),
-  );
+  Widget defaultWidget({double? opacity}) => Container(
+        decoration: BoxDecoration(
+          gradient: LinearGradient(
+            begin: Alignment.topLeft,
+            end: Alignment.bottomRight,
+            colors: [
+              Colors.grey[300]!.withOpacity(opacity ?? 1),
+              Colors.grey[200]!.withOpacity(opacity ?? 1),
+            ],
+          ),
+        ),
+      );
 
-  Widget _loadingImageWidget({required String? data}) {
+  Widget _loadingImageWidget({required String? data, double? opacity}) {
     return Builder(
       builder: (context) {
         if (data != null) {
           return Image.network(
             data,
             fit: BoxFit.fitHeight,
-            errorBuilder: (context, error, stackTrace) => defaultWidget,
+            errorBuilder: (context, error, stackTrace) =>
+                defaultWidget(opacity: opacity),
           );
         } else {
-          return defaultWidget;
+          return defaultWidget(opacity: opacity);
         }
       },
     );
@@ -54,18 +61,16 @@ class _OotdDetailScreenState extends State<OotdDetailScreen> {
 
   @override
   Widget build(BuildContext context) {
-    log('build() 호출');
+    log('build() 호출 ${widget._id}');
     return SafeArea(
         child: Stack(
       fit: StackFit.expand,
       alignment: Alignment.bottomCenter,
       children: [
-        Builder(builder: (context) {
-          return PinchZoom(
-            child: _loadingImageWidget(
-                data: context.watch<OotdDetailViewModel>().feed?.imagePath),
-          );
-        }),
+        PinchZoom(
+          child: _loadingImageWidget(
+              data: widget._mainImagePath),
+        ),
         GestureDetector(
           onTap: _changeArea,
           child: Visibility(
@@ -88,7 +93,7 @@ class _OotdDetailScreenState extends State<OotdDetailScreen> {
                   ? Alignment.topCenter
                   : Alignment.bottomCenter,
               curve: Curves.easeOutQuint,
-              duration: const Duration(milliseconds: 500),
+              duration: const Duration(milliseconds: 300),
               child: Container(
                 height: _isCancelAreaShow ? _detailAreaExpandHeight : null,
                 width: MediaQuery.of(context).size.width,
@@ -120,7 +125,8 @@ class _OotdDetailScreenState extends State<OotdDetailScreen> {
                                               .code ??
                                           0)
                                       .iconPath,
-                                  errorBuilder: (_, __, ___) => defaultWidget),
+                                  errorBuilder: (_, __, ___) =>
+                                      defaultWidget(opacity: 0.2)),
                             ),
                             const SizedBox(
                               width: 8,
@@ -131,7 +137,7 @@ class _OotdDetailScreenState extends State<OotdDetailScreen> {
                                   fontWeight: FontWeight.w800,
                                   color: Colors.white),
                               child: Text(
-                                  '${context.watch<OotdDetailViewModel>().feed?.weather.temperature.toString() ?? '--'}°C'),
+                                  '${context.watch<OotdDetailViewModel>().feed?.weather.temperature.toString() ?? ''}°C'),
                             ),
                             const Spacer(),
                             DefaultTextStyle(
@@ -144,7 +150,7 @@ class _OotdDetailScreenState extends State<OotdDetailScreen> {
                                       .feed
                                       ?.createdAt
                                       .toFormat() ??
-                                  '--'),
+                                  ''),
                             ),
                             Visibility(
                                 maintainSize: false,
@@ -237,7 +243,7 @@ class _OotdDetailScreenState extends State<OotdDetailScreen> {
                                           .watch<OotdDetailViewModel>()
                                           .feed
                                           ?.description ??
-                                      '--',
+                                      '',
                                   overflow: _isCancelAreaShow
                                       ? null
                                       : TextOverflow.ellipsis,
@@ -273,6 +279,7 @@ class _OotdDetailScreenState extends State<OotdDetailScreen> {
                         width: 40,
                         height: 40,
                         child: _loadingImageWidget(
+                            opacity: 0.2,
                             data: context
                                 .watch<OotdDetailViewModel>()
                                 .userProfile
@@ -291,7 +298,7 @@ class _OotdDetailScreenState extends State<OotdDetailScreen> {
                               .watch<OotdDetailViewModel>()
                               .feed
                               ?.userEmail ??
-                          '----'),
+                          ''),
                     ),
                     const Spacer(),
                     IconButton(
@@ -299,7 +306,7 @@ class _OotdDetailScreenState extends State<OotdDetailScreen> {
                         Icons.close,
                         size: 24,
                       ),
-                      color: Colors.black,
+                      color: Colors.white,
                       onPressed: () => context.pop(),
                     )
                   ],

--- a/lib/presentation/ootd_feed_detail/view/ootd_feed_detail.dart
+++ b/lib/presentation/ootd_feed_detail/view/ootd_feed_detail.dart
@@ -103,7 +103,7 @@ class _OotdDetailScreenState extends State<OotdDetailScreen> {
               curve: Curves.easeOutQuint,
               duration: const Duration(milliseconds: 300),
               child: Container(
-                height: _isCancelAreaShow ? _detailAreaExpandHeight : null,
+                height: _isCancelAreaShow ? _detailAreaExpandHeight : 135,
                 width: MediaQuery.of(context).size.width,
                 decoration: const BoxDecoration(
                   borderRadius: BorderRadius.only(
@@ -113,7 +113,7 @@ class _OotdDetailScreenState extends State<OotdDetailScreen> {
                 ),
                 child: Padding(
                   padding:
-                      const EdgeInsets.symmetric(vertical: 18, horizontal: 18),
+                      const EdgeInsets.fromLTRB(16, 16, 16, 8),
                   child: Builder(builder: (context) {
                     log('하단 시트 build() 호출');
                     return Column(
@@ -185,7 +185,7 @@ class _OotdDetailScreenState extends State<OotdDetailScreen> {
                           ],
                         ),
                         const SizedBox(
-                          height: 16,
+                          height: 12,
                         ),
                         Row(
                           children: [
@@ -233,10 +233,9 @@ class _OotdDetailScreenState extends State<OotdDetailScreen> {
                           ],
                         ),
                         const SizedBox(
-                          height: 24,
+                          height: 16,
                         ),
-                        SizedBox(
-                          height: _isCancelAreaShow ? 274 : null,
+                        Expanded(
                           child: SingleChildScrollView(
                             scrollDirection: Axis.vertical,
                             child: Align(

--- a/lib/presentation/ootd_feed_detail/view_model/ootd_detail_view_model.dart
+++ b/lib/presentation/ootd_feed_detail/view_model/ootd_detail_view_model.dart
@@ -1,3 +1,4 @@
+import 'dart:developer';
 import 'package:flutter/material.dart';
 import 'package:weaco/domain/feed/model/feed.dart';
 import 'package:weaco/domain/feed/use_case/get_detail_feed_detail_use_case.dart';
@@ -30,7 +31,7 @@ class OotdDetailViewModel extends ChangeNotifier {
           (throw Exception());
       _userProfile = (await _getUserProfileUseCase.execute(email: _feed!.userEmail));
     } catch (e) {
-      throw Exception();
+      log(e.toString(), name: 'OotdDetailViewModel._getFeedDetail()');
     }
     notifyListeners();
   }

--- a/lib/presentation/ootd_feed_detail/view_model/ootd_detail_view_model.dart
+++ b/lib/presentation/ootd_feed_detail/view_model/ootd_detail_view_model.dart
@@ -25,9 +25,13 @@ class OotdDetailViewModel extends ChangeNotifier {
   }
 
   Future<void> _getFeedDetail({required String id}) async {
-    _feed = (await _getDetailFeedDetailUseCase.execute(id: id)) ??
-        (throw Exception());
-    _userProfile = (await _getUserProfileUseCase.execute(email: _feed!.userEmail));
+    try {
+      _feed = (await _getDetailFeedDetailUseCase.execute(id: id)) ??
+          (throw Exception());
+      _userProfile = (await _getUserProfileUseCase.execute(email: _feed!.userEmail));
+    } catch (e) {
+      throw Exception();
+    }
     notifyListeners();
   }
 }


### PR DESCRIPTION
## :: 최근 작업 주제 (하나 이상의 주제를 선택해주세요.)
- [x] 기능 추가
- [ ] 리뷰 반영
- [ ] 리팩토링
- [ ] 버그 수정
- [ ] 컨벤션 수정

<br />

## :: 구현 목표 (해당 브랜치에서 구현하고자 하는 하나의 목표를 설정합니다.)
- OOTD 피드 화면 데이터 연결
- OOTD 피드 화면, 상세 화면 UI 수정

<br />

## :: 구현 사항 설명 (작업한 내용을 상세하게 기록합니다.)
1. OotdFeedViewModel, getSearchFeedsUseCase 연결

2. OOTD 피드 화면 PageView 스크롤 애니메이션 변경

3. OOTD 피드 화면, OOTD 상세 화면 연결
피드 id값 전달

4. OOTD 상세 화면 UI 수정
없는 프로필의 프로필 이미지 투명도 조정
하단 시트 애니메이션 속도 및 색상 조정

5. OOTD 피드 화면 UI 수정
좌,우 힌트 카드 크기 축소
카드 크기 및 힌트 카드와의 여백 변경
카드의 Flip 상태 유지

6. OotdFeedViewModel, OotdDetailViewModel, GetIt을 통한 의존성 주입


<br />

## :: 성장 포인트 (해당 기능을 구현하며 고민했던 사항이나 새로 알게된 부분, 어려웠던 점 등을 작성합니다.)
- OOTD 피드 화면의 카드(PageView)와 OOTD 상세 화면의 배경 이미지에 Hero 애니메이션을 적용하였지만, 의도와 다르게 동작하여 롤백하였습니다.
  - 상세화면을 pop하는 경우, Hero 애니메이션이 카드보다 큰 공간을 차지하면서 좌/우 힌트 카드가 화면 밖으로 밀려난 뒤, 애니메이션이 작아짐에 따라 다시 제자리로 돌아옵니다.
  - 해당 애니메이션이 부자연스럽고, 카드가 화면의 중앙에 크게 위치하여 기본으로 제공되는 push/pop 애니메이션이  Hero와 유사한 UX를 주어 롤백하였습니다.
- 사용자가 PageView 리스트를 직접 스크롤하지 못하게 구현하였습니다.
  - 직접 스크롤할 경우, 스와이프에 즉각적으로 스크롤이 반응하여, 상/하 스와이프를 의도한 스와이프에서도 좌/우 스크롤이 이동하였습니다.
- OOTD 피드 화면의 카드(PageView)에서만 좌/우 및 상/하 스와이프가 가능하게 하였습니다. 
  - 카드에 대한 스와이프를 인식하여좌/우 스크롤 및 상/하 카드 Flip을 애니메이션으로 수행하도록 처리하였습니다.

<br />

## :: 기타 질문 및 특이 사항
- Data Layer에서DailyLocationWeather를 가져다 쓰기로 기획이 변경되어 GetOotdFeedsUseCase를 수정하여야 합니다.  우선 GetSearchFeedsUseCase를 사용하였고, 추후 다시 리팩토링 하겠습니다.
