### PR TITLE
Feat/#50 user page screen UI viewmodel

### DIFF
--- a/lib/core/di/di_setup.dart
+++ b/lib/core/di/di_setup.dart
@@ -7,6 +7,9 @@ import 'package:weaco/core/di/user/user_di_setup.dart';
 import 'package:weaco/core/di/weather/weather_di_setup.dart';
 import 'package:weaco/domain/file/use_case/save_image_use_case.dart';
 import 'package:weaco/presentation/ootd_post/picture_crop/picutre_crop_view_model.dart';
+import 'package:weaco/domain/feed/use_case/get_user_page_feeds_use_case.dart';
+import 'package:weaco/domain/user/use_case/get_user_profile_use_case.dart';
+import 'package:weaco/presentation/user_page/user_page_view_model.dart';
 
 final getIt = GetIt.instance;
 
@@ -33,4 +36,11 @@ void diSetup() {
     () => PictureCropViewModel(saveImageUseCase: getIt<SaveImageUseCase>()),
   );
   // View
+  getIt.registerFactoryParam<UserPageViewModel, String, void>(
+    (param1, _) => UserPageViewModel(
+      email: param1,
+      getUserProfileUseCase: getIt<GetUserProfileUseCase>(),
+      getUserPageFeedsUseCase: getIt<GetUserPageFeedsUseCase>(),
+    ),
+  );
 }

--- a/lib/core/go_router/router.dart
+++ b/lib/core/go_router/router.dart
@@ -8,6 +8,7 @@ import 'package:weaco/domain/weather/use_case/get_daily_location_weather_use_cas
 import 'package:weaco/main.dart';
 import 'package:weaco/presentation/ootd_feed/view/ootd_feed_screen.dart';
 import 'package:weaco/presentation/ootd_feed/view_model/ootd_feed_view_model.dart';
+import 'package:weaco/presentation/ootd_post/ootd_post_view_model.dart';
 import 'package:weaco/presentation/ootd_post/picture_crop/picutre_crop_view_model.dart';
 import 'package:weaco/presentation/home/screen/home_screen.dart';
 import 'package:weaco/presentation/home/view_model/home_screen_view_model.dart';
@@ -18,6 +19,7 @@ import 'package:weaco/presentation/ootd_post/camera_view_model.dart';
 import 'package:weaco/presentation/ootd_post/ootd_post_screen.dart';
 import 'package:weaco/presentation/ootd_post/picture_crop/picture_crop_screen.dart';
 import 'package:weaco/presentation/sign_in/screen/sign_in_screen.dart';
+import 'package:weaco/presentation/sign_in/view_model/sign_in_view_model.dart';
 import 'package:weaco/presentation/sign_up/screen/sign_up_screen.dart';
 import 'package:weaco/presentation/user_page/user_page_screen.dart';
 import 'package:weaco/presentation/user_page/user_page_view_model.dart';
@@ -52,8 +54,10 @@ final router = GoRouter(
     ),
     GoRoute(
       path: RouterPath.signIn.path,
-      // builder: (context, state) => SignInScreen(),
-      builder: (context, state) => const SignInScreen(),
+      builder: (context, state) => ChangeNotifierProvider(
+        create: (_) => getIt<SignInViewModel>(),
+        child: const SignInScreen(),
+      ),
     ),
     GoRoute(
       path: RouterPath.dialog.path,
@@ -136,7 +140,12 @@ final router = GoRouter(
     ),
     GoRoute(
       path: RouterPath.ootdPost.path,
-      builder: (context, state) => const OotdPostScreen(),
+      builder: (context, state) {
+        return ChangeNotifierProvider(
+          create: (_) => getIt<OotdPostViewModel>(),
+          child: const OotdPostScreen(),
+        );
+      },
     ),
   ],
 );

--- a/lib/core/go_router/router.dart
+++ b/lib/core/go_router/router.dart
@@ -80,9 +80,7 @@ final router = GoRouter(
       path: RouterPath.userPage.path,
       builder: (context, state) => ChangeNotifierProvider(
         create: (context) => getIt<UserPageViewModel>(
-          // param1: state.uri.queryParameters['email'],
-          // param1: 'dummyId4@gmail.com',
-          param1: 'deletedUser@delete.com',
+          param1: state.uri.queryParameters['email'],
         ),
         child: const UserPageScreen(),
       ),

--- a/lib/core/go_router/router.dart
+++ b/lib/core/go_router/router.dart
@@ -9,16 +9,18 @@ import 'package:weaco/main.dart';
 import 'package:weaco/presentation/ootd_feed/view/ootd_feed_screen.dart';
 import 'package:weaco/presentation/ootd_feed/view_model/ootd_feed_view_model.dart';
 import 'package:weaco/presentation/ootd_post/picture_crop/picutre_crop_view_model.dart';
-import 'package:weaco/presentation/sign_up/screen/sign_up_screen.dart';
-import 'package:weaco/presentation/sign_in/screen/sign_in_screen.dart';
 import 'package:weaco/presentation/home/screen/home_screen.dart';
 import 'package:weaco/presentation/home/view_model/home_screen_view_model.dart';
 import 'package:weaco/presentation/ootd_feed_detail/view/ootd_feed_detail.dart';
+import 'package:weaco/presentation/ootd_feed_detail/view_model/ootd_detail_view_model.dart';
 import 'package:weaco/presentation/ootd_post/camera_screen.dart';
 import 'package:weaco/presentation/ootd_post/camera_view_model.dart';
-import 'package:weaco/presentation/ootd_feed_detail/view_model/ootd_detail_view_model.dart';
 import 'package:weaco/presentation/ootd_post/ootd_post_screen.dart';
 import 'package:weaco/presentation/ootd_post/picture_crop/picture_crop_screen.dart';
+import 'package:weaco/presentation/sign_in/screen/sign_in_screen.dart';
+import 'package:weaco/presentation/sign_up/screen/sign_up_screen.dart';
+import 'package:weaco/presentation/user_page/user_page_screen.dart';
+import 'package:weaco/presentation/user_page/user_page_view_model.dart';
 
 final router = GoRouter(
   initialLocation: '/',
@@ -35,9 +37,9 @@ final router = GoRouter(
         return ChangeNotifierProvider(
           create: (_) => HomeScreenViewModel(
             getDailyLocationWeatherUseCase:
-            getIt<GetDailyLocationWeatherUseCase>(),
+                getIt<GetDailyLocationWeatherUseCase>(),
             getBackgroundImageListUseCase:
-            getIt<GetBackgroundImageListUseCase>(),
+                getIt<GetBackgroundImageListUseCase>(),
             getRecommendedFeedsUseCase: getIt<GetRecommendedFeedsUseCase>(),
           ),
           child: const HomeScreen(),
@@ -76,9 +78,11 @@ final router = GoRouter(
     ),
     GoRoute(
       path: RouterPath.userPage.path,
-      // builder: (context, state) => UserPageScreen(),
-      builder: (context, state) => const MyHomePage(
-        title: '',
+      builder: (context, state) => ChangeNotifierProvider(
+        create: (context) => getIt<UserPageViewModel>(
+          param1: state.uri.queryParameters['email'],
+        ),
+        child: const UserPageScreen(),
       ),
     ),
     GoRoute(
@@ -101,8 +105,12 @@ final router = GoRouter(
       path: RouterPath.ootdDetail.path,
       builder: (context, state) {
         return ChangeNotifierProvider(
-          create: (_) => getIt<OotdDetailViewModel>(param1: state.uri.queryParameters['id'] ?? ''),
-          child: OotdDetailScreen(id: state.uri.queryParameters['id'] ?? '', mainImagePath: state.uri.queryParameters['imagePath'] ?? '',),
+          create: (_) => getIt<OotdDetailViewModel>(
+              param1: state.uri.queryParameters['id'] ?? ''),
+          child: OotdDetailScreen(
+            id: state.uri.queryParameters['id'] ?? '',
+            mainImagePath: state.uri.queryParameters['imagePath'] ?? '',
+          ),
         );
       },
     ),
@@ -120,11 +128,13 @@ final router = GoRouter(
       // builder: (context, state) => PictureCropScreen(
       //   sourcePath: state.extra as String,
       // ),
-    // ),
-    builder: (context, state) {
+      // ),
+      builder: (context, state) {
         return ChangeNotifierProvider(
           create: (_) => getIt<PictureCropViewModel>(),
-          child: PictureCropScreen(sourcePath: state.extra as String,),
+          child: PictureCropScreen(
+            sourcePath: state.extra as String,
+          ),
         );
       },
     ),

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -2,8 +2,10 @@ import 'package:flutter/material.dart';
 import 'package:firebase_core/firebase_core.dart';
 import 'package:flutter_dotenv/flutter_dotenv.dart';
 import 'package:flutter_localizations/flutter_localizations.dart';
+import 'package:go_router/go_router.dart';
 import 'package:hive_flutter/hive_flutter.dart';
 import 'package:weaco/core/di/di_setup.dart';
+import 'package:weaco/core/enum/router_path.dart';
 import 'package:weaco/core/go_router/router.dart';
 import 'package:weaco/core/go_router/router_static.dart';
 import 'package:weaco/presentation/navigation_bar/bottom_navigation_widget.dart';
@@ -97,7 +99,9 @@ class _MyHomePageState extends State<MyHomePage> {
               child: const Text('Go to MyPageScreen'),
             ),
             TextButton(
-              onPressed: () {},
+              onPressed: () {
+                context.push(RouterPath.userPage.path);
+              },
               child: const Text('Go to UserPageScreen'),
             ),
             TextButton(

--- a/lib/presentation/user_page/component/feed_grid/feed_grid_deleted_user_widget.dart
+++ b/lib/presentation/user_page/component/feed_grid/feed_grid_deleted_user_widget.dart
@@ -1,0 +1,29 @@
+import 'package:flutter/material.dart';
+
+class FeedGridDeletedUserWidget extends StatelessWidget {
+  const FeedGridDeletedUserWidget({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return const Expanded(
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.center,
+        mainAxisAlignment: MainAxisAlignment.center,
+        children: [
+          Icon(
+            Icons.camera_alt_outlined,
+            size: 56,
+          ),
+          SizedBox(height: 8),
+          Text(
+            '찾을 수 없는 사용자입니다.',
+            style: TextStyle(
+              fontSize: 16,
+              fontWeight: FontWeight.bold,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/presentation/user_page/component/feed_grid/feed_grid_empty_widget.dart
+++ b/lib/presentation/user_page/component/feed_grid/feed_grid_empty_widget.dart
@@ -1,0 +1,29 @@
+import 'package:flutter/material.dart';
+
+class FeedGridEmptyWidget extends StatelessWidget {
+  const FeedGridEmptyWidget({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return const Expanded(
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.center,
+        mainAxisAlignment: MainAxisAlignment.center,
+        children: [
+          Icon(
+            Icons.camera_alt_outlined,
+            size: 56,
+          ),
+          SizedBox(height: 8),
+          Text(
+            '피드가 없습니다.',
+            style: TextStyle(
+              fontSize: 16,
+              fontWeight: FontWeight.bold,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/presentation/user_page/component/user_profile/user_profile_deleted_widget.dart
+++ b/lib/presentation/user_page/component/user_profile/user_profile_deleted_widget.dart
@@ -1,0 +1,57 @@
+import 'package:flutter/material.dart';
+import 'package:weaco/domain/user/model/user_profile.dart';
+
+class UserProfileDeletedWidget extends StatelessWidget {
+  final UserProfile _userProfile;
+
+  const UserProfileDeletedWidget({
+    super.key,
+    required UserProfile userProfile,
+  }) : _userProfile = userProfile;
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      children: [
+        Row(
+          children: [
+            Padding(
+              padding: const EdgeInsets.symmetric(horizontal: 12),
+              child: CircleAvatar(
+                maxRadius: 32,
+                backgroundImage: NetworkImage(_userProfile.profileImagePath),
+              ),
+            ),
+            Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(
+                  _userProfile.nickname,
+                  style: const TextStyle(
+                    fontSize: 20,
+                    fontWeight: FontWeight.bold,
+                  ),
+                ),
+                const Text(''),
+              ],
+            ),
+          ],
+        ),
+        const Padding(
+          padding: EdgeInsets.only(top: 8),
+          child: Row(
+            mainAxisAlignment: MainAxisAlignment.end,
+            children: [
+              Text(
+                '',
+                style: TextStyle(
+                  color: Colors.black54,
+                ),
+              ),
+            ],
+          ),
+        ),
+      ],
+    );
+  }
+}

--- a/lib/presentation/user_page/component/user_profile/user_profile_widget.dart
+++ b/lib/presentation/user_page/component/user_profile/user_profile_widget.dart
@@ -1,0 +1,63 @@
+import 'package:flutter/material.dart';
+import 'package:weaco/domain/user/model/user_profile.dart';
+
+class UserProfileWidget extends StatelessWidget {
+  final UserProfile _userProfile;
+
+  const UserProfileWidget({
+    super.key,
+    required UserProfile userProfile,
+  }) : _userProfile = userProfile;
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      children: [
+        Row(
+          children: [
+            Padding(
+              padding: const EdgeInsets.symmetric(horizontal: 12),
+              child: CircleAvatar(
+                maxRadius: 32,
+                backgroundImage: NetworkImage(_userProfile.profileImagePath),
+              ),
+            ),
+            Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(
+                  _userProfile.nickname,
+                  style: const TextStyle(
+                    fontSize: 20,
+                    fontWeight: FontWeight.bold,
+                  ),
+                ),
+                Text(
+                  _userProfile.email.split('@')[0],
+                  style: const TextStyle(
+                    fontSize: 12,
+                    color: Colors.black26,
+                  ),
+                ),
+              ],
+            ),
+          ],
+        ),
+        Padding(
+          padding: const EdgeInsets.only(top: 8),
+          child: Row(
+            mainAxisAlignment: MainAxisAlignment.end,
+            children: [
+              Text(
+                '게시물 ${_userProfile.feedCount}',
+                style: const TextStyle(
+                  color: Colors.black54,
+                ),
+              ),
+            ],
+          ),
+        ),
+      ],
+    );
+  }
+}

--- a/lib/presentation/user_page/user_page_screen.dart
+++ b/lib/presentation/user_page/user_page_screen.dart
@@ -1,9 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter/rendering.dart';
-import 'package:flutter/widgets.dart';
-import 'package:go_router/go_router.dart';
 import 'package:provider/provider.dart';
-import 'package:weaco/core/enum/router_path.dart';
 import 'package:weaco/core/go_router/router_static.dart';
 import 'package:weaco/domain/feed/model/feed.dart';
 import 'package:weaco/domain/user/model/user_profile.dart';

--- a/lib/presentation/user_page/user_page_screen.dart
+++ b/lib/presentation/user_page/user_page_screen.dart
@@ -1,0 +1,113 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/rendering.dart';
+import 'package:flutter/widgets.dart';
+import 'package:go_router/go_router.dart';
+import 'package:provider/provider.dart';
+import 'package:weaco/core/enum/router_path.dart';
+import 'package:weaco/domain/feed/model/feed.dart';
+import 'package:weaco/domain/user/model/user_profile.dart';
+import 'package:weaco/presentation/user_page/component/user_profile/user_profile_deleted_widget.dart';
+import 'package:weaco/presentation/user_page/component/user_profile/user_profile_widget.dart';
+import 'package:weaco/presentation/user_page/user_page_view_model.dart';
+
+class UserPageScreen extends StatefulWidget {
+  const UserPageScreen({super.key});
+
+  @override
+  State<UserPageScreen> createState() => _UserPageScreenState();
+}
+
+class _UserPageScreenState extends State<UserPageScreen> {
+  @override
+  Widget build(BuildContext context) {
+    UserPageViewModel userPageViewModel = context.read<UserPageViewModel>();
+
+    bool isPageLoading = context.watch<UserPageViewModel>().isPageLoading;
+
+    UserProfile? userProfile = context.read<UserPageViewModel>().userProfile;
+    List<Feed> userFeedList = context.watch<UserPageViewModel>().userFeedList;
+
+    return Scaffold(
+      appBar: AppBar(
+        backgroundColor: Theme.of(context).scaffoldBackgroundColor,
+        scrolledUnderElevation: 0,
+      ),
+      body: isPageLoading || userProfile == null
+          ? const Center(child: CircularProgressIndicator())
+          : Padding(
+              padding: const EdgeInsets.symmetric(horizontal: 20, vertical: 28),
+              child: Column(
+                children: [
+                  userProfile.deletedAt == null
+                      ? UserProfileWidget(userProfile: userProfile)
+                      : UserProfileDeletedWidget(userProfile: userProfile),
+                  const Divider(),
+                  userFeedList.isEmpty
+                      ? const Expanded(
+                          child: Column(
+                            crossAxisAlignment: CrossAxisAlignment.center,
+                            mainAxisAlignment: MainAxisAlignment.center,
+                            children: [
+                              Icon(
+                                Icons.camera_alt_outlined,
+                                size: 56,
+                              ),
+                              SizedBox(height: 8),
+                              Text(
+                                '피드가 없습니다.',
+                                style: TextStyle(
+                                  fontSize: 16,
+                                  fontWeight: FontWeight.bold,
+                                ),
+                              ),
+                            ],
+                          ),
+                        )
+                      : NotificationListener<UserScrollNotification>(
+                          onNotification:
+                              (UserScrollNotification notification) {
+                            if (notification.direction ==
+                                    ScrollDirection.reverse &&
+                                notification.metrics.maxScrollExtent * 0.9 <
+                                    notification.metrics.pixels) {
+                              userPageViewModel.fetchFeed();
+                            }
+
+                            return false;
+                          },
+                          child: Expanded(
+                            child: GridView.builder(
+                              physics: const AlwaysScrollableScrollPhysics(),
+                              itemCount: userFeedList.length,
+                              gridDelegate:
+                                  const SliverGridDelegateWithFixedCrossAxisCount(
+                                childAspectRatio: 3 / 4,
+                                crossAxisSpacing: 4,
+                                mainAxisSpacing: 4,
+                                crossAxisCount: 3,
+                              ),
+                              itemBuilder: (context, index) {
+                                return GestureDetector(
+                                  onTap: () {
+                                    context.push(
+                                        '${RouterPath.ootdDetail.path}?id=${userFeedList[index].id}&imagePath=${userFeedList[index].imagePath}');
+                                  },
+                                  child: ClipRRect(
+                                    borderRadius: BorderRadius.circular(2),
+                                    child: Image(
+                                      image: NetworkImage(
+                                          userFeedList[index].imagePath),
+                                      fit: BoxFit.cover,
+                                    ),
+                                  ),
+                                );
+                              },
+                            ),
+                          ),
+                        ),
+                ],
+              ),
+            ),
+    );
+  }
+}

--- a/lib/presentation/user_page/user_page_screen.dart
+++ b/lib/presentation/user_page/user_page_screen.dart
@@ -6,6 +6,8 @@ import 'package:provider/provider.dart';
 import 'package:weaco/core/enum/router_path.dart';
 import 'package:weaco/domain/feed/model/feed.dart';
 import 'package:weaco/domain/user/model/user_profile.dart';
+import 'package:weaco/presentation/user_page/component/feed_grid/feed_grid_deleted_user_widget.dart';
+import 'package:weaco/presentation/user_page/component/feed_grid/feed_grid_empty_widget.dart';
 import 'package:weaco/presentation/user_page/component/user_profile/user_profile_deleted_widget.dart';
 import 'package:weaco/presentation/user_page/component/user_profile/user_profile_widget.dart';
 import 'package:weaco/presentation/user_page/user_page_view_model.dart';
@@ -42,69 +44,53 @@ class _UserPageScreenState extends State<UserPageScreen> {
                       ? UserProfileWidget(userProfile: userProfile)
                       : UserProfileDeletedWidget(userProfile: userProfile),
                   const Divider(),
-                  userFeedList.isEmpty
-                      ? const Expanded(
-                          child: Column(
-                            crossAxisAlignment: CrossAxisAlignment.center,
-                            mainAxisAlignment: MainAxisAlignment.center,
-                            children: [
-                              Icon(
-                                Icons.camera_alt_outlined,
-                                size: 56,
-                              ),
-                              SizedBox(height: 8),
-                              Text(
-                                '피드가 없습니다.',
-                                style: TextStyle(
-                                  fontSize: 16,
-                                  fontWeight: FontWeight.bold,
+                  userProfile.deletedAt != null
+                      ? const FeedGridDeletedUserWidget()
+                      : userFeedList.isEmpty
+                          ? const FeedGridEmptyWidget()
+                          : NotificationListener<UserScrollNotification>(
+                              onNotification:
+                                  (UserScrollNotification notification) {
+                                if (notification.direction ==
+                                        ScrollDirection.reverse &&
+                                    notification.metrics.maxScrollExtent * 0.9 <
+                                        notification.metrics.pixels) {
+                                  userPageViewModel.fetchFeed();
+                                }
+
+                                return false;
+                              },
+                              child: Expanded(
+                                child: GridView.builder(
+                                  physics:
+                                      const AlwaysScrollableScrollPhysics(),
+                                  itemCount: userFeedList.length,
+                                  gridDelegate:
+                                      const SliverGridDelegateWithFixedCrossAxisCount(
+                                    childAspectRatio: 3 / 4,
+                                    crossAxisSpacing: 4,
+                                    mainAxisSpacing: 4,
+                                    crossAxisCount: 3,
+                                  ),
+                                  itemBuilder: (context, index) {
+                                    return GestureDetector(
+                                      onTap: () {
+                                        context.push(
+                                            '${RouterPath.ootdDetail.path}?id=${userFeedList[index].id}&imagePath=${userFeedList[index].imagePath}');
+                                      },
+                                      child: ClipRRect(
+                                        borderRadius: BorderRadius.circular(2),
+                                        child: Image(
+                                          image: NetworkImage(
+                                              userFeedList[index].imagePath),
+                                          fit: BoxFit.cover,
+                                        ),
+                                      ),
+                                    );
+                                  },
                                 ),
                               ),
-                            ],
-                          ),
-                        )
-                      : NotificationListener<UserScrollNotification>(
-                          onNotification:
-                              (UserScrollNotification notification) {
-                            if (notification.direction ==
-                                    ScrollDirection.reverse &&
-                                notification.metrics.maxScrollExtent * 0.9 <
-                                    notification.metrics.pixels) {
-                              userPageViewModel.fetchFeed();
-                            }
-
-                            return false;
-                          },
-                          child: Expanded(
-                            child: GridView.builder(
-                              physics: const AlwaysScrollableScrollPhysics(),
-                              itemCount: userFeedList.length,
-                              gridDelegate:
-                                  const SliverGridDelegateWithFixedCrossAxisCount(
-                                childAspectRatio: 3 / 4,
-                                crossAxisSpacing: 4,
-                                mainAxisSpacing: 4,
-                                crossAxisCount: 3,
-                              ),
-                              itemBuilder: (context, index) {
-                                return GestureDetector(
-                                  onTap: () {
-                                    context.push(
-                                        '${RouterPath.ootdDetail.path}?id=${userFeedList[index].id}&imagePath=${userFeedList[index].imagePath}');
-                                  },
-                                  child: ClipRRect(
-                                    borderRadius: BorderRadius.circular(2),
-                                    child: Image(
-                                      image: NetworkImage(
-                                          userFeedList[index].imagePath),
-                                      fit: BoxFit.cover,
-                                    ),
-                                  ),
-                                );
-                              },
                             ),
-                          ),
-                        ),
                 ],
               ),
             ),

--- a/lib/presentation/user_page/user_page_screen.dart
+++ b/lib/presentation/user_page/user_page_screen.dart
@@ -4,6 +4,7 @@ import 'package:flutter/widgets.dart';
 import 'package:go_router/go_router.dart';
 import 'package:provider/provider.dart';
 import 'package:weaco/core/enum/router_path.dart';
+import 'package:weaco/core/go_router/router_static.dart';
 import 'package:weaco/domain/feed/model/feed.dart';
 import 'package:weaco/domain/user/model/user_profile.dart';
 import 'package:weaco/presentation/user_page/component/feed_grid/feed_grid_deleted_user_widget.dart';
@@ -22,12 +23,11 @@ class UserPageScreen extends StatefulWidget {
 class _UserPageScreenState extends State<UserPageScreen> {
   @override
   Widget build(BuildContext context) {
-    UserPageViewModel userPageViewModel = context.read<UserPageViewModel>();
+    UserPageViewModel userPageViewModel = context.watch<UserPageViewModel>();
 
-    bool isPageLoading = context.watch<UserPageViewModel>().isPageLoading;
-
-    UserProfile? userProfile = context.read<UserPageViewModel>().userProfile;
-    List<Feed> userFeedList = context.watch<UserPageViewModel>().userFeedList;
+    final UserProfile? userProfile = userPageViewModel.userProfile;
+    final List<Feed> userFeedList = userPageViewModel.userFeedList;
+    final bool isPageLoading = userPageViewModel.isPageLoading;
 
     return Scaffold(
       appBar: AppBar(
@@ -53,7 +53,8 @@ class _UserPageScreenState extends State<UserPageScreen> {
                                   (UserScrollNotification notification) {
                                 if (notification.direction ==
                                         ScrollDirection.reverse &&
-                                    notification.metrics.maxScrollExtent * 0.9 <
+                                    notification.metrics.maxScrollExtent *
+                                            0.85 <
                                         notification.metrics.pixels) {
                                   userPageViewModel.fetchFeed();
                                 }
@@ -75,8 +76,12 @@ class _UserPageScreenState extends State<UserPageScreen> {
                                   itemBuilder: (context, index) {
                                     return GestureDetector(
                                       onTap: () {
-                                        context.push(
-                                            '${RouterPath.ootdDetail.path}?id=${userFeedList[index].id}&imagePath=${userFeedList[index].imagePath}');
+                                        RouterStatic.goToOotdDetail(
+                                          context,
+                                          id: userFeedList[index].id ?? '',
+                                          imagePath:
+                                              userFeedList[index].imagePath,
+                                        );
                                       },
                                       child: ClipRRect(
                                         borderRadius: BorderRadius.circular(2),

--- a/lib/presentation/user_page/user_page_view_model.dart
+++ b/lib/presentation/user_page/user_page_view_model.dart
@@ -1,0 +1,120 @@
+import 'dart:developer';
+
+import 'package:flutter/widgets.dart';
+import 'package:weaco/core/exception/not_found_exception.dart';
+import 'package:weaco/domain/feed/model/feed.dart';
+import 'package:weaco/domain/feed/use_case/get_user_page_feeds_use_case.dart';
+import 'package:weaco/domain/user/model/user_profile.dart';
+import 'package:weaco/domain/user/use_case/get_user_profile_use_case.dart';
+
+class UserPageViewModel with ChangeNotifier {
+  final String _email;
+  final GetUserProfileUseCase _getUserProfileUseCase;
+  final GetUserPageFeedsUseCase _getUserPageFeedsUseCase;
+
+  UserPageViewModel({
+    required String email,
+    required GetUserProfileUseCase getUserProfileUseCase,
+    required GetUserPageFeedsUseCase getUserPageFeedsUseCase,
+  })  : _email = email,
+        _getUserProfileUseCase = getUserProfileUseCase,
+        _getUserPageFeedsUseCase = getUserPageFeedsUseCase {
+    initializeUserPageData();
+  }
+
+  static const _count = 21;
+
+  UserProfile? _userProfile;
+  List<Feed> _userFeedList = [];
+
+  bool _isPageLoading = false;
+  bool _isFeedListLoading = false;
+
+  DateTime _lastFeedDateTime = DateTime.now();
+
+  UserProfile? get userProfile => _userProfile;
+
+  List<Feed> get userFeedList => _userFeedList;
+
+  bool get isPageLoading => _isPageLoading;
+
+  bool get isFeedListLoading => _isFeedListLoading;
+
+  DateTime? get lastFeedDateTime => _lastFeedDateTime;
+
+  Future<void> initializeUserPageData() async {
+    changePageLoadingStatus(true);
+    await getUserProfile(_email);
+    await getInitialUserFeedList(_email);
+    changePageLoadingStatus(false);
+
+    setLastFeedDateTime();
+    notifyListeners();
+  }
+
+  void changePageLoadingStatus(bool status) {
+    _isPageLoading = status;
+  }
+
+  void changeFeedListLoadingStatus(bool status) {
+    _isFeedListLoading = status;
+  }
+
+  void setLastFeedDateTime() {
+    _lastFeedDateTime = _userFeedList[_userFeedList.length - 1].createdAt;
+  }
+
+  Future<void> getUserProfile(String email) async {
+    try {
+      final result = await _getUserProfileUseCase.execute(email: email);
+
+      if (result == null) {
+        throw NotFoundException(
+          code: 404,
+          message: '이메일과 일치하는 사용자가 없습니다.',
+        );
+      }
+
+      _userProfile = result;
+    } on Exception catch (e) {
+      log(e.toString(), name: 'UserPageViewModel.getUserProfile()');
+    }
+  }
+
+  Future<void> getInitialUserFeedList(String email) async {
+    try {
+      _userFeedList = await _getUserPageFeedsUseCase.execute(
+        email: email,
+        createdAt: null,
+        limit: _count,
+      );
+    } on Exception catch (e) {
+      log(e.toString(), name: 'UserPageViewModel.getInitialUserFeedList()');
+    }
+  }
+
+  Future<void> fetchFeed() async {
+    if (!_isFeedListLoading) {
+      changeFeedListLoadingStatus(true);
+
+      if (_userProfile!.feedCount == _userFeedList.length) return;
+
+      final result = await _getUserPageFeedsUseCase.execute(
+        email: _email,
+        createdAt: _lastFeedDateTime,
+        limit: _count,
+      );
+
+      _userFeedList.addAll(result);
+
+      log('feed loaded', name: 'UserPageViewModel.fetchFeed()');
+      log(_userFeedList.length.toString(),
+          name: 'UserPageViewModel.fetchFeed()');
+
+      changeFeedListLoadingStatus(false);
+      setLastFeedDateTime();
+
+      notifyListeners();
+    }
+  }
+}

--- a/lib/presentation/user_page/user_page_view_model.dart
+++ b/lib/presentation/user_page/user_page_view_model.dart
@@ -49,19 +49,21 @@ class UserPageViewModel with ChangeNotifier {
     changePageLoadingStatus(false);
 
     setLastFeedDateTime();
-    notifyListeners();
   }
 
   void changePageLoadingStatus(bool status) {
     _isPageLoading = status;
+    notifyListeners();
   }
 
   void changeFeedListLoadingStatus(bool status) {
     _isFeedListLoading = status;
+    notifyListeners();
   }
 
   void setLastFeedDateTime() {
     _lastFeedDateTime = _userFeedList[_userFeedList.length - 1].createdAt;
+    notifyListeners();
   }
 
   Future<void> getUserProfile(String email) async {
@@ -79,6 +81,7 @@ class UserPageViewModel with ChangeNotifier {
     } on Exception catch (e) {
       log(e.toString(), name: 'UserPageViewModel.getUserProfile()');
     }
+    notifyListeners();
   }
 
   Future<void> getInitialUserFeedList(String email) async {
@@ -91,6 +94,7 @@ class UserPageViewModel with ChangeNotifier {
     } on Exception catch (e) {
       log(e.toString(), name: 'UserPageViewModel.getInitialUserFeedList()');
     }
+    notifyListeners();
   }
 
   Future<void> fetchFeed() async {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -58,6 +58,7 @@ dependencies:
   intl: ^0.18.1
   flutter_localizations:
     sdk: flutter
+  infinite_scroll_pagination: ^4.0.0
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
## :: 최근 작업 주제 (하나 이상의 주제를 선택해주세요.)
- [X] 기능 추가
- [x] 리뷰 반영
- [x] 리팩토링
- [x] 버그 수정
- [ ] 컨벤션 수정

<br />

## :: 구현 목표 (해당 브랜치에서 구현하고자 하는 하나의 목표를 설정합니다.)
- UserPageScreen 구현
- UserProfileWidget, UserProfileDeletedWidget 구현
- 피드 무한 스크롤 페이지네이션 구현
- FeedGridDeletedUserWidget, FeedGridEmptyWidget
- UserPageViewModel 작성

<br />

## :: 구현 사항 설명 (작업한 내용을 상세하게 기록합니다.)
1. UserPageScreen 작성
  - UserProfile 의 deletedAt 값에 따라 삭제된 유저 또는 유저의 정보를 보이도록 구현
  - List<Feed> 에 따라 피드 리스트에서 피드 또는 피드 없음을 나타내도록 구현

2. Feed 그리드 뷰 무한스크롤페이지네에션 구현
  - 피드 개수에 따라 각각 다른 위젯을 보여주도록 구현
  - NotificationListener, GridView.builder 사용하여 무한스크롤페이지네이션 구현

<br />

## :: 성장 포인트 (해당 기능을 구현하며 고민했던 사항이나 새로 알게된 부분, 어려웠던 점 등을 작성합니다.)
- 패키지 등을 사용하려 구현하려고 했던 무한스크롤 페이지네이션을 기본 위젯을 사용하여 구현해보았습니다.
- 유저 정보, 피드 정보 등을 이용하여 다른 화면을 보여주는 로직을 작성하였습니다.
- PTR 과 무한스크롤페이지네이션을 함께 구현하려고 했지만 기본위젯의 한계로 현재 구현에서 제외시켰습니다.

<br />

## :: 기타 질문 및 특이 사항
- PTR 구현 제외, 추후 구현 필요
