### PR TITLE
Feat/#184 editing ootd screen ui viewmodel

### DIFF
--- a/lib/core/go_router/router.dart
+++ b/lib/core/go_router/router.dart
@@ -3,6 +3,7 @@ import 'package:go_router/go_router.dart';
 import 'package:provider/provider.dart';
 import 'package:weaco/core/di/di_setup.dart';
 import 'package:weaco/core/enum/router_path.dart';
+import 'package:weaco/domain/feed/model/feed.dart';
 import 'package:weaco/domain/user/use_case/log_out_use_case.dart';
 import 'package:weaco/domain/user/use_case/sign_out_use_case.dart';
 import 'package:weaco/domain/feed/use_case/get_recommended_feeds_use_case.dart';
@@ -165,7 +166,9 @@ final router = GoRouter(
       builder: (context, state) {
         return ChangeNotifierProvider(
           create: (_) => getIt<OotdPostViewModel>(),
-          child: const OotdPostScreen(),
+          child: OotdPostScreen(
+            feed: state.extra as Feed?,
+          ),
         );
       },
     ),

--- a/lib/core/go_router/router_static.dart
+++ b/lib/core/go_router/router_static.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:weaco/core/enum/router_path.dart';
 import 'package:weaco/core/go_router/router.dart';
+import 'package:weaco/domain/feed/model/feed.dart';
 
 class RouterStatic {
   static void goToDefault(BuildContext context) {
@@ -74,7 +75,11 @@ class RouterStatic {
     router.go(RouterPath.pictureCrop.path, extra: path);
   }
 
-  static void goToOotdPost(BuildContext context) {
-    router.go(RouterPath.ootdPost.path);
+  static void goToOotdPost(BuildContext context, {Feed? feed}) {
+    router.go(RouterPath.ootdPost.path, extra: feed);
+  }
+
+  static void popFromOotdPost(BuildContext context) {
+    router.pop(RouterPath.ootdPost.path);
   }
 }

--- a/lib/presentation/ootd_post/ootd_post_view_model.dart
+++ b/lib/presentation/ootd_post/ootd_post_view_model.dart
@@ -17,6 +17,7 @@ class OotdPostViewModel with ChangeNotifier {
   final SaveEditFeedUseCase _saveEditFeedUseCase;
   final SaveImageUseCase _saveImageUseCase;
   bool _showSpinner = false;
+  bool _saveStatus = false;
   File? _originImage;
   File? _croppedImage;
   Weather? _weather;
@@ -53,7 +54,7 @@ class OotdPostViewModel with ChangeNotifier {
     notifyListeners();
   }
 
-  void saveFeed(String description, Function(bool) callback) async {
+  Future<void> saveFeed(String description) async {
     final now = DateTime.now();
     final Feed feed = Feed(
       id: null,
@@ -76,9 +77,22 @@ class OotdPostViewModel with ChangeNotifier {
       createdAt: now,
     );
 
-    final result = await _saveEditFeedUseCase.execute(feed: feed);
+    _saveStatus = await _saveEditFeedUseCase.execute(feed: feed);
+  }
 
-    callback(result);
+  Future<void> editFeed(Feed feed, String description) async {
+    final editedFeed = Feed(
+      id: feed.id,
+      imagePath: feed.imagePath,
+      userEmail: feed.userEmail,
+      description: description,
+      weather: feed.weather,
+      seasonCode: feed.seasonCode,
+      location: feed.location,
+      createdAt: feed.createdAt,
+    );
+
+    _saveStatus = await _saveEditFeedUseCase.execute(feed: editedFeed);
   }
 
   Future<void> getOriginImage() async {
@@ -103,6 +117,8 @@ class OotdPostViewModel with ChangeNotifier {
   Weather? get weather => _weather;
 
   DailyLocationWeather? get dailyLocationWeather => _dailyLocationWeather;
+
+  bool get saveStatus => _saveStatus;
 
   bool get showSpinner => _showSpinner;
 }


### PR DESCRIPTION
## :: 최근 작업 주제 (하나 이상의 주제를 선택해주세요.)
- [x] 기능 추가
- [ ] 리뷰 반영
- [x] 리팩토링
- [ ] 버그 수정
- [ ] 컨벤션 수정

<br />

## :: 구현 목표 (해당 브랜치에서 구현하고자 하는 하나의 목표를 설정합니다.)
- 피드 수정 로직 구현
- OotdPostViewModel.saveFeed() 리팩토링
=> 콜백 메서드를 지우고 viewModel 상태 값을 저장하여 view에서 읽도록 수정하였습니다.

<br />

## :: 구현 사항 설명 (작업한 내용을 상세하게 기록합니다.)
1. 기존 Feed의 데이터를 가져옵니다.
2. 피드 수정 시에는 피드글만 수정이 가능합니다.
3. '뒤로 가기' 버튼을 누르면 이전 화면으로 돌아갑니다.
4. '수정' 버튼을 누르면 수정된 피드글이 저장되고 이전 화면으로 돌아갑니다.

<br />

## :: 성장 포인트 (해당 기능을 구현하며 고민했던 사항이나 새로 알게된 부분, 어려웠던 점 등을 작성합니다.)

<br />

## :: 기타 질문 및 특이 사항
