### PR TITLE
Feat: sign up, sign in 인풋창 힌트 텍스트 정렬 및 다이얼로그 텍스트 위젯 변경

### DIFF
--- a/lib/core/go_router/router_static.dart
+++ b/lib/core/go_router/router_static.dart
@@ -16,7 +16,7 @@ class RouterStatic {
     router.pop(RouterPath.home.path);
   }
 
-  static void goToSignUp(BuildContext context) {
+  static void pushToSignUp(BuildContext context) {
     router.push(RouterPath.signUp.path);
   }
 

--- a/lib/presentation/common/component/dialog/one_button_dialog.dart
+++ b/lib/presentation/common/component/dialog/one_button_dialog.dart
@@ -28,24 +28,25 @@ class OneButtonDialog extends StatelessWidget {
       content: Column(
         mainAxisSize: MainAxisSize.min,
         children: [
-          SizedBox(
-            width: 200,
-            height: 100,
-            child: Column(
-              mainAxisAlignment: MainAxisAlignment.center,
-              children: [
-                Text(
-                  content,
-                  textAlign: TextAlign.center,
-                  style: const TextStyle(
-                    color: Color(0xFF1D1B20),
-                    fontSize: 18,
-                    fontFamily: 'Roboto',
-                    fontWeight: FontWeight.w700,
-                    height: 0.10,
+          Padding(
+            padding: const EdgeInsets.symmetric(vertical: 24),
+            child: SizedBox(
+              width: 200,
+              child: Column(
+                mainAxisAlignment: MainAxisAlignment.center,
+                children: [
+                  Text(
+                    content,
+                    textAlign: TextAlign.center,
+                    style: const TextStyle(
+                      color: Color(0xFF1D1B20),
+                      fontSize: 18,
+                      fontFamily: 'Roboto',
+                      fontWeight: FontWeight.w700,
+                    ),
                   ),
-                ),
-              ],
+                ],
+              ),
             ),
           ),
           Padding(

--- a/lib/presentation/common/component/dialog/one_button_dialog.dart
+++ b/lib/presentation/common/component/dialog/one_button_dialog.dart
@@ -41,7 +41,6 @@ class OneButtonDialog extends StatelessWidget {
                     style: const TextStyle(
                       color: Color(0xFF1D1B20),
                       fontSize: 18,
-                      fontFamily: 'Roboto',
                       fontWeight: FontWeight.w700,
                     ),
                   ),
@@ -74,7 +73,6 @@ class OneButtonDialog extends StatelessWidget {
                         style: const TextStyle(
                           color: Colors.white,
                           fontSize: 16,
-                          fontFamily: 'Roboto',
                           fontWeight: FontWeight.w600,
                           height: 0,
                         ),

--- a/lib/presentation/common/component/dialog/two_button_dialog.dart
+++ b/lib/presentation/common/component/dialog/two_button_dialog.dart
@@ -47,7 +47,6 @@ class TwoButtonDialog extends StatelessWidget {
                     style: const TextStyle(
                       color: Color(0xFF1D1B20),
                       fontSize: 18,
-                      fontFamily: 'Roboto',
                       fontWeight: FontWeight.w700,
                     ),
                   ),
@@ -80,7 +79,6 @@ class TwoButtonDialog extends StatelessWidget {
                         style: const TextStyle(
                           color: Colors.white,
                           fontSize: 16,
-                          fontFamily: 'Roboto',
                           fontWeight: FontWeight.w600,
                           height: 0,
                         ),
@@ -110,7 +108,6 @@ class TwoButtonDialog extends StatelessWidget {
                         style: const TextStyle(
                           color: Colors.white,
                           fontSize: 16,
-                          fontFamily: 'Roboto',
                           fontWeight: FontWeight.w600,
                           height: 0,
                         ),

--- a/lib/presentation/common/component/dialog/two_button_dialog.dart
+++ b/lib/presentation/common/component/dialog/two_button_dialog.dart
@@ -34,24 +34,25 @@ class TwoButtonDialog extends StatelessWidget {
       content: Column(
         mainAxisSize: MainAxisSize.min,
         children: [
-          SizedBox(
-            width: 200,
-            height: 100,
-            child: Column(
-              mainAxisAlignment: MainAxisAlignment.center,
-              children: [
-                Text(
-                  content,
-                  textAlign: TextAlign.center,
-                  style: const TextStyle(
-                    color: Color(0xFF1D1B20),
-                    fontSize: 18,
-                    fontFamily: 'Roboto',
-                    fontWeight: FontWeight.w700,
-                    height: 0.10,
+          Padding(
+            padding: const EdgeInsets.symmetric(vertical: 24),
+            child: SizedBox(
+              width: 200,
+              child: Column(
+                mainAxisAlignment: MainAxisAlignment.center,
+                children: [
+                  Text(
+                    content,
+                    textAlign: TextAlign.center,
+                    style: const TextStyle(
+                      color: Color(0xFF1D1B20),
+                      fontSize: 18,
+                      fontFamily: 'Roboto',
+                      fontWeight: FontWeight.w700,
+                    ),
                   ),
-                ),
-              ],
+                ],
+              ),
             ),
           ),
           Padding(

--- a/lib/presentation/home/component/recommand_login_bottom_sheet_widget.dart
+++ b/lib/presentation/home/component/recommand_login_bottom_sheet_widget.dart
@@ -54,7 +54,7 @@ class RecommandLoginBottomSheetWidget extends StatelessWidget {
                 ),
               ),
               onPressed: () {
-                RouterStatic.goToSignUp(context);
+                RouterStatic.pushToSignUp(context);
                 context.pop();
               },
               child: const Text(

--- a/lib/presentation/sign_in/screen/sign_in_screen.dart
+++ b/lib/presentation/sign_in/screen/sign_in_screen.dart
@@ -377,7 +377,7 @@ class _SignInScreenState extends State<SignInScreen> {
             password: passwordFormController.text)
         .then((_) {
       context.read<UserProvider>().signIn(email: emailFormController.text);
-      RouterStatic.goToHome(context);
+      RouterStatic.goToDefault(context);
     }).catchError((e) {
       AlertUtil.showAlert(
         context: context,

--- a/lib/presentation/sign_in/screen/sign_in_screen.dart
+++ b/lib/presentation/sign_in/screen/sign_in_screen.dart
@@ -194,7 +194,6 @@ class _SignInScreenState extends State<SignInScreen> {
                       fontSize: 16,
                       fontFamily: 'Roboto',
                       fontWeight: FontWeight.w400,
-                      height: 0,
                     ),
                     border: InputBorder.none,
                     fillColor: const Color(0xFFF3F3F3),
@@ -246,7 +245,6 @@ class _SignInScreenState extends State<SignInScreen> {
                         fontSize: 16,
                         fontFamily: 'Roboto',
                         fontWeight: FontWeight.w400,
-                        height: 0,
                       ),
                       border: InputBorder.none,
                       fillColor: const Color(0xFFF3F3F3),
@@ -338,7 +336,7 @@ class _SignInScreenState extends State<SignInScreen> {
       width: double.infinity,
       height: 54,
       child: InkWell(
-        onTap: () => RouterStatic.goToSignUp(context),
+        onTap: () => RouterStatic.pushToSignUp(context),
         child: Container(
           decoration: BoxDecoration(
             color: Colors.transparent,

--- a/lib/presentation/sign_in/screen/sign_in_screen.dart
+++ b/lib/presentation/sign_in/screen/sign_in_screen.dart
@@ -192,7 +192,6 @@ class _SignInScreenState extends State<SignInScreen> {
                     hintStyle: const TextStyle(
                       color: Color(0xFF797979),
                       fontSize: 16,
-                      fontFamily: 'Roboto',
                       fontWeight: FontWeight.w400,
                     ),
                     border: InputBorder.none,
@@ -243,7 +242,6 @@ class _SignInScreenState extends State<SignInScreen> {
                       hintStyle: const TextStyle(
                         color: Color(0xFF797979),
                         fontSize: 16,
-                        fontFamily: 'Roboto',
                         fontWeight: FontWeight.w400,
                       ),
                       border: InputBorder.none,
@@ -322,7 +320,6 @@ class _SignInScreenState extends State<SignInScreen> {
             style: TextStyle(
               color: Colors.white,
               fontSize: 16,
-              fontFamily: 'Roboto',
               fontWeight: FontWeight.w600,
             ),
           ),
@@ -349,7 +346,6 @@ class _SignInScreenState extends State<SignInScreen> {
             style: TextStyle(
               color: Color(0xFF292929),
               fontSize: 16,
-              fontFamily: 'Roboto',
               fontWeight: FontWeight.w400,
             ),
           ),

--- a/lib/presentation/sign_in/view_model/sign_in_view_model.dart
+++ b/lib/presentation/sign_in/view_model/sign_in_view_model.dart
@@ -28,9 +28,7 @@ class SignInViewModel extends ChangeNotifier {
       rethrow;
     } catch (e) {
       String? message;
-      print('signIn ex bool ${e is FirebaseException}');
       if (e is FirebaseException) {
-        print('ex code ${e.code}');
         message = switch (e.code) {
           'user-not-found' => '존재하지 않는 유저입니다.',
           'wrong-password' => '비밀번호가 맞지 않습니다.',

--- a/lib/presentation/sign_in/view_model/sign_in_view_model.dart
+++ b/lib/presentation/sign_in/view_model/sign_in_view_model.dart
@@ -1,3 +1,4 @@
+import 'package:firebase_core/firebase_core.dart';
 import 'package:flutter/cupertino.dart';
 import 'package:weaco/core/exception/custom_business_exception.dart';
 import 'package:weaco/domain/user/model/user_auth.dart';
@@ -26,8 +27,25 @@ class SignInViewModel extends ChangeNotifier {
 
       rethrow;
     } catch (e) {
+      String? message;
+      if (e is FirebaseException) {
+        message = switch (e.code) {
+          'user-not-found' => '존재하지 않는 유저입니다.',
+          'wrong-password' => '비밀번호가 맞지 않습니다.',
+          'email-already-in-use' => '이미 가입된 이메일입니다.',
+          'invalid-email' => '이메일 형식이 올바르지 못합니다.',
+          'operation-not-allowed' => '허용되지 않는 요청입니다.',
+          'weak-password' => '비밀번호 형식이 안전하지 않습니다.',
+          'network-request-failed' => '네트워크가 불안정 합니다.',
+          'too-many-requests' => '요청이 너무 많습니다.',
+          'user-disabled' => '이미 탈퇴한 회원입니다.',
+          _ => null,
+        };
+      }
+
       exceptionState = ExceptionState(
-          message: e.toString(), exceptionAlert: ExceptionAlert.snackBar);
+          message: message ?? '로그인에 실패 하였습니다.',
+          exceptionAlert: ExceptionAlert.snackBar);
 
       rethrow;
     }

--- a/lib/presentation/sign_in/view_model/sign_in_view_model.dart
+++ b/lib/presentation/sign_in/view_model/sign_in_view_model.dart
@@ -28,7 +28,9 @@ class SignInViewModel extends ChangeNotifier {
       rethrow;
     } catch (e) {
       String? message;
+      print('signIn ex bool ${e is FirebaseException}');
       if (e is FirebaseException) {
+        print('ex code ${e.code}');
         message = switch (e.code) {
           'user-not-found' => '존재하지 않는 유저입니다.',
           'wrong-password' => '비밀번호가 맞지 않습니다.',
@@ -39,6 +41,7 @@ class SignInViewModel extends ChangeNotifier {
           'network-request-failed' => '네트워크가 불안정 합니다.',
           'too-many-requests' => '요청이 너무 많습니다.',
           'user-disabled' => '이미 탈퇴한 회원입니다.',
+          'invalid-credential' => '이메일과 비밀번호를 확인해주세요.',
           _ => null,
         };
       }

--- a/lib/presentation/sign_up/screen/sign_up_screen.dart
+++ b/lib/presentation/sign_up/screen/sign_up_screen.dart
@@ -168,7 +168,6 @@ class _SignUpScreenState extends State<SignUpScreen> {
                 fontSize: 16,
                 fontFamily: 'Roboto',
                 fontWeight: FontWeight.w400,
-                height: 0,
               ),
               border: InputBorder.none,
               fillColor: const Color(0xFFF3F3F3),
@@ -319,16 +318,18 @@ class _SignUpScreenState extends State<SignUpScreen> {
       nickname: nicknameFormController.text,
       genderCode: selectedGender,
     )
-        .then((_) {
-      context.read<UserProvider>().signIn(email: emailFormController.text);
-      AlertUtil.showAlert(
-        context: context,
-        exceptionAlert: ExceptionAlert.dialog,
-        message: '회원가입에 성공하였습니다.',
-        buttonText: '둘러보기',
-        onPressedCheck: () => RouterStatic.goToHome(context),
-      );
-    },).catchError((e) {
+        .then(
+      (_) {
+        context.read<UserProvider>().signIn(email: emailFormController.text);
+        AlertUtil.showAlert(
+          context: context,
+          exceptionAlert: ExceptionAlert.dialog,
+          message: '회원가입에 성공하였습니다.',
+          buttonText: '둘러보기',
+          onPressedCheck: () => RouterStatic.goToDefault(context),
+        );
+      },
+    ).catchError((e) {
       AlertUtil.showAlert(
         context: context,
         exceptionAlert: signUpViewModel.exceptionState!.exceptionAlert,

--- a/lib/presentation/sign_up/screen/sign_up_screen.dart
+++ b/lib/presentation/sign_up/screen/sign_up_screen.dart
@@ -87,7 +87,6 @@ class _SignUpScreenState extends State<SignUpScreen> {
             style: TextStyle(
               color: Color(0xFF1A1C29),
               fontSize: 20,
-              fontFamily: 'Roboto',
               fontWeight: FontWeight.w700,
             ),
           ),
@@ -97,7 +96,6 @@ class _SignUpScreenState extends State<SignUpScreen> {
             style: TextStyle(
               color: Color(0xFF797979),
               fontSize: 15,
-              fontFamily: 'Roboto',
               fontWeight: FontWeight.w400,
             ),
           ),
@@ -166,7 +164,6 @@ class _SignUpScreenState extends State<SignUpScreen> {
               hintStyle: const TextStyle(
                 color: Color(0xFF797979),
                 fontSize: 16,
-                fontFamily: 'Roboto',
                 fontWeight: FontWeight.w400,
               ),
               border: InputBorder.none,
@@ -260,7 +257,6 @@ class _SignUpScreenState extends State<SignUpScreen> {
               style: const TextStyle(
                 color: Color(0xFF1A1C29),
                 fontSize: 16,
-                fontFamily: 'Roboto',
                 fontWeight: FontWeight.w500,
               ),
             ),
@@ -290,7 +286,6 @@ class _SignUpScreenState extends State<SignUpScreen> {
             style: TextStyle(
               color: Color(0xF5F5F5FF),
               fontSize: 16,
-              fontFamily: 'Roboto',
               fontWeight: FontWeight.w600,
             ),
           ),

--- a/lib/presentation/sign_up/view_model/sign_up_view_model.dart
+++ b/lib/presentation/sign_up/view_model/sign_up_view_model.dart
@@ -1,5 +1,6 @@
 import 'dart:math';
 
+import 'package:firebase_core/firebase_core.dart';
 import 'package:flutter/foundation.dart';
 import 'package:weaco/core/enum/gender_code.dart';
 import 'package:weaco/core/exception/custom_business_exception.dart';
@@ -44,8 +45,25 @@ class SignUpViewModel extends ChangeNotifier {
 
       rethrow;
     } catch (e) {
+      String? message;
+      if (e is FirebaseException) {
+        message = switch (e.code) {
+          'user-not-found' => '존재하지 않는 유저입니다.',
+          'wrong-password' => '비밀번호가 맞지 않습니다.',
+          'email-already-in-use' => '이미 가입된 이메일입니다.',
+          'invalid-email' => '이메일 형식이 올바르지 못합니다.',
+          'operation-not-allowed' => '허용되지 않는 요청입니다.',
+          'weak-password' => '비밀번호 형식이 안전하지 않습니다.',
+          'network-request-failed' => '네트워크가 불안정 합니다.',
+          'too-many-requests' => '요청이 너무 많습니다.',
+          'user-disabled' => '이미 탈퇴한 회원입니다.',
+          _ => null,
+        };
+      }
+
       exceptionState = ExceptionState(
-          message: e.toString(), exceptionAlert: ExceptionAlert.snackBar);
+          message: message ?? '회원가입에 실패 하였습니다.',
+          exceptionAlert: ExceptionAlert.snackBar);
 
       rethrow;
     }

--- a/lib/presentation/sign_up/view_model/sign_up_view_model.dart
+++ b/lib/presentation/sign_up/view_model/sign_up_view_model.dart
@@ -57,6 +57,7 @@ class SignUpViewModel extends ChangeNotifier {
           'network-request-failed' => '네트워크가 불안정 합니다.',
           'too-many-requests' => '요청이 너무 많습니다.',
           'user-disabled' => '이미 탈퇴한 회원입니다.',
+          'invalid-credential' => '이메일과 비밀번호를 확인해주세요.',
           _ => null,
         };
       }


### PR DESCRIPTION
## :: 최근 작업 주제 (하나 이상의 주제를 선택해주세요.)
- [x] 기능 추가
- [ ] 리뷰 반영
- [ ] 리팩토링
- [x] 버그 수정
- [ ] 컨벤션 수정

<br />

## :: 구현 목표 (해당 브랜치에서 구현하고자 하는 하나의 목표를 설정합니다.)
- 로그인, 회원가입 실패시 예외처리 추가
- 로그인, 회원가입 인풋창 힌트 텍스트 중앙정렬
- 다이얼로그 텍스트 유동적으로 길이 조절 가능하게 변경

<br />

## :: 구현 사항 설명 (작업한 내용을 상세하게 기록합니다.)
- 로그인, 회원가입 실패시 예외처리 추가
1. Firebase Auth 예외에 따라 메세지를 핸들링

- 로그인, 회원가입 인풋창 힌트 텍스트 중앙정렬
1. 각 인풋창 height 값 제거

- 다이얼로그 텍스트 유동적으로 길이 조절 가능하게 변경
1. 다이얼로그 텍스트 height 값 제거

<br />

## :: 성장 포인트 (해당 기능을 구현하며 고민했던 사항이나 새로 알게된 부분, 어려웠던 점 등을 작성합니다.)

<br />

## :: 기타 질문 및 특이 사항
