### PR TITLE
Feat/#216 logout and signout routing and my page user data reset

### DIFF
--- a/lib/core/go_router/router_static.dart
+++ b/lib/core/go_router/router_static.dart
@@ -4,6 +4,13 @@ import 'package:weaco/core/go_router/router.dart';
 import 'package:weaco/domain/feed/model/feed.dart';
 
 class RouterStatic {
+  static void clearAndNavigate(BuildContext context, String path) {
+    while (router.canPop() == true) {
+      router.pop();
+    }
+    router.pushReplacement(path);
+  }
+
   static void goToDefault(BuildContext context) {
     router.go(RouterPath.defaultPage.path);
   }
@@ -11,6 +18,7 @@ class RouterStatic {
   static void replaceToDefault(BuildContext context) {
     router.replace(RouterPath.defaultPage.path);
   }
+
   static void goToHome(BuildContext context) {
     router.go(RouterPath.home.path);
   }
@@ -71,8 +79,7 @@ class RouterStatic {
     router.push(RouterPath.ootdFeed.path);
   }
 
-  static void pushToOotdDetail(BuildContext context,
-      {required Feed feed}) {
+  static void pushToOotdDetail(BuildContext context, {required Feed feed}) {
     router.push(RouterPath.ootdDetail.path, extra: feed);
   }
 

--- a/lib/presentation/my_page/screen/my_page_screen.dart
+++ b/lib/presentation/my_page/screen/my_page_screen.dart
@@ -6,6 +6,7 @@ import 'package:weaco/core/enum/router_path.dart';
 import 'package:weaco/core/go_router/router_static.dart';
 import 'package:weaco/domain/feed/model/feed.dart';
 import 'package:weaco/domain/user/model/user_profile.dart';
+import 'package:weaco/presentation/common/user_provider.dart';
 import 'package:weaco/presentation/my_page/screen/component/my_profile_widget.dart';
 import 'package:weaco/presentation/my_page/view_model/my_page_view_model.dart';
 import 'package:weaco/presentation/user_page/screen/component/feed_grid/feed_grid_empty_widget.dart';
@@ -18,6 +19,19 @@ class MyPageScreen extends StatefulWidget {
 }
 
 class _MyPageScreenState extends State<MyPageScreen> {
+  @override
+  void initState() {
+    super.initState();
+
+    Future.microtask(() {
+      if (context.read<UserProvider>().email == null) {
+        context.read<MyPageViewModel>().clearMyPageViewModelState();
+      } else {
+        context.read<MyPageViewModel>().initializePageData();
+      }
+    });
+  }
+
   @override
   Widget build(BuildContext context) {
     MyPageViewModel myPageViewModel = context.watch<MyPageViewModel>();
@@ -45,7 +59,7 @@ class _MyPageScreenState extends State<MyPageScreen> {
                       Icons.settings,
                     ),
                     onPressed: () {
-                      RouterStatic.pushToAppSetting(context);
+                      RouterStatic.goToAppSetting(context);
                     },
                   ),
                 ],
@@ -113,10 +127,7 @@ class _MyPageScreenState extends State<MyPageScreen> {
 
     return GestureDetector(
       onTap: () {
-        RouterStatic.pushToOotdDetail(
-          context,
-          feed: currentFeed
-        );
+        RouterStatic.pushToOotdDetail(context, feed: currentFeed);
       },
       onLongPress: () {
         showModalBottomSheet(

--- a/lib/presentation/my_page/view_model/my_page_view_model.dart
+++ b/lib/presentation/my_page/view_model/my_page_view_model.dart
@@ -19,9 +19,7 @@ class MyPageViewModel with ChangeNotifier {
     required RemoveMyPageFeedUseCase removeMyPageFeedUseCase,
   })  : _getMyPageUserProfileUseCase = getMyPageUserProfileUseCase,
         _getMyPageFeedsUseCase = getMyPageFeedsUseCase,
-        _removeMyPageFeedUseCase = removeMyPageFeedUseCase {
-    initializePageData();
-  }
+        _removeMyPageFeedUseCase = removeMyPageFeedUseCase;
 
   static const _fetchCount = 21;
   static const _fetchMoreCount = 9;
@@ -177,5 +175,12 @@ class MyPageViewModel with ChangeNotifier {
     if (_profile != null) {
       _profile = _profile!.copyWith(feedCount: _profile!.feedCount - 1);
     }
+  }
+
+  void clearMyPageViewModelState() {
+    _profile = null;
+    _feedList.clear();
+
+    notifyListeners();
   }
 }

--- a/lib/presentation/settings/screen/app_setting_screen.dart
+++ b/lib/presentation/settings/screen/app_setting_screen.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
 import 'package:provider/provider.dart';
+import 'package:weaco/core/enum/router_path.dart';
 import 'package:weaco/core/go_router/router_static.dart';
 import 'package:weaco/presentation/common/enum/exception_alert.dart';
 import 'package:weaco/presentation/common/user_provider.dart';
@@ -104,12 +105,13 @@ class _AppSettingScreenState extends State<AppSettingScreen> {
     context.read<AppSettingViewModel>().logOut().then((value) {
       if (value) {
         context.read<UserProvider>().signOut();
-        RouterStatic.replaceToDefault(context);
 
         AlertUtil.showAlert(
             context: context,
             exceptionAlert: ExceptionAlert.snackBar,
             message: '로그아웃에 성공했습니다.');
+
+        RouterStatic.clearAndNavigate(context, RouterPath.defaultPage.path);
       } else {
         AlertUtil.showAlert(
             context: context,
@@ -125,11 +127,13 @@ class _AppSettingScreenState extends State<AppSettingScreen> {
     context.read<AppSettingViewModel>().signOut().then((value) {
       if (value) {
         context.read<UserProvider>().signOut();
-        RouterStatic.replaceToDefault(context);
+
         AlertUtil.showAlert(
             context: context,
             exceptionAlert: ExceptionAlert.snackBar,
             message: '회원탈퇴에 성공했습니다.');
+
+        RouterStatic.clearAndNavigate(context, RouterPath.defaultPage.path);
       } else {
         AlertUtil.showAlert(
             context: context,


### PR DESCRIPTION
## :: 최근 작업 주제 (하나 이상의 주제를 선택해주세요.)
- [ ] 기능 추가
- [ ] 리뷰 반영
- [ ] 리팩토링
- [X] 버그 수정
- [ ] 컨벤션 수정

<br />

## :: 구현 목표 (해당 브랜치에서 구현하고자 하는 하나의 목표를 설정합니다.)
- 로그아웃, 회원탈퇴 시 라우팅 문제 해결
- MyPageScreen 에서 뷰모델 상태 초기화 및 이전 상태 유지 문제 해결

<br />

## :: 구현 사항 설명 (작업한 내용을 상세하게 기록합니다.)
- `MyPageViewModel` 에서 생성자 바디에서 뷰모델의 상태를 initialize 하는 로직을 삭제 했습니다.
- `MyPageScreen` 의 `initState` 생명주기함수에서 `UserProvider.email` 값에 따라 뷰모델의 상태를 clear 하거나 initialize 하는 로직을 추가했습니다.
- `RouterStatic` 클래스에서 네비게이션 스택을 비우고 원하는 경로의 화면으로 이동할 수 있는 `clearAndNavigate()` 메소드를 추가했습니다
- `AppSettingScreen` 의 `_logOutSubmit()` `_signOutSubmit()` 메소드에서 `RouterStatic.clearAndNavigate()` 메소드를 사용하여 로그아웃, 회원탈퇴 이후에 메인페이지로 이동하게 하는 로직으로 수정했습니다.
- 로그아웃, 회원탈퇴 이후에 뒤로가기를 했을 때 마이페이지로 이동되던 문제를 수정했습니다.

<br />

## :: 성장 포인트 (해당 기능을 구현하며 고민했던 사항이나 새로 알게된 부분, 어려웠던 점 등을 작성합니다.)

<br />

## :: 기타 질문 및 특이 사항

