### PR TITLE
Feat: 홈 화면 진입 시 피드 검색 페이지 최초 피드 20개 이미지 프리 캐싱처리

### DIFF
--- a/lib/core/di/di_setup.dart
+++ b/lib/core/di/di_setup.dart
@@ -7,6 +7,7 @@ import 'package:weaco/core/di/user/user_di_setup.dart';
 import 'package:weaco/core/di/weather/weather_di_setup.dart';
 import 'package:weaco/domain/feed/use_case/get_my_page_feeds_use_case.dart';
 import 'package:weaco/domain/feed/use_case/get_recommended_feeds_use_case.dart';
+import 'package:weaco/domain/feed/use_case/get_search_feeds_use_case.dart';
 import 'package:weaco/domain/feed/use_case/remove_my_page_feed_use_case.dart';
 import 'package:weaco/domain/user/repository/user_auth_repository.dart';
 import 'package:weaco/domain/user/use_case/get_my_profile_use_case.dart';
@@ -61,6 +62,7 @@ void diSetup() {
       getDailyLocationWeatherUseCase: getIt<GetDailyLocationWeatherUseCase>(),
       getBackgroundImageListUseCase: getIt<GetBackgroundImageListUseCase>(),
       getRecommendedFeedsUseCase: getIt<GetRecommendedFeedsUseCase>(),
+      getSearchFeedsUseCase: getIt<GetSearchFeedsUseCase>(),
     ),
   );
 

--- a/lib/presentation/common/component/cached_image_widget.dart
+++ b/lib/presentation/common/component/cached_image_widget.dart
@@ -24,6 +24,7 @@ class CachedImageWidget extends StatelessWidget {
     return CachedNetworkImage(
       fit: _boxFit ?? BoxFit.cover,
       imageUrl: _imageUrl,
+      // Flip Card 위젯 높이와 동일 = 16 * 35
       memCacheHeight: (16 * 35).cacheSize(context),
       progressIndicatorBuilder: (context, url, downloadProgress) =>
           _progressIndicatorBuilder ??

--- a/lib/presentation/home/component/recommend_ootd_list_widget.dart
+++ b/lib/presentation/home/component/recommend_ootd_list_widget.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:collection/collection.dart';
 import 'package:weaco/core/go_router/router_static.dart';
 import 'package:weaco/domain/feed/model/feed.dart';
 import 'package:weaco/domain/weather/model/daily_location_weather.dart';
@@ -40,21 +41,17 @@ class RecommendOotdListWidget extends StatelessWidget {
                     ),
                   )
                 : Expanded(
-                    child: ListView.builder(
+                    child: ListView(
                       scrollDirection: Axis.horizontal,
-                      itemCount: feedList.length,
-                      itemBuilder: (context, index) {
-                        return GestureDetector(
-                          onTap: () => RouterStatic.pushToOotdDetail(
+                      children: feedList.mapIndexed((index, element) => GestureDetector(
+                        onTap: () => RouterStatic.pushToOotdDetail(
                             context,
-                            feed: feedList[index]
-                          ),
-                          child: RecommendOotdWidget(
-                            feedList: feedList,
-                            index: index,
-                          ),
-                        );
-                      },
+                            feed: element),
+                        child: RecommendOotdWidget(
+                          feedList: feedList,
+                          index: index,
+                        ),
+                      )).toList()
                     ),
                   ),
           ],

--- a/lib/presentation/home/component/recommend_ootd_list_widget.dart
+++ b/lib/presentation/home/component/recommend_ootd_list_widget.dart
@@ -1,5 +1,4 @@
 import 'package:flutter/material.dart';
-import 'package:collection/collection.dart';
 import 'package:weaco/core/go_router/router_static.dart';
 import 'package:weaco/domain/feed/model/feed.dart';
 import 'package:weaco/domain/weather/model/daily_location_weather.dart';
@@ -43,13 +42,13 @@ class RecommendOotdListWidget extends StatelessWidget {
                 : Expanded(
                     child: ListView(
                       scrollDirection: Axis.horizontal,
-                      children: feedList.mapIndexed((index, element) => GestureDetector(
+                      children: feedList.indexed.map((e) => GestureDetector(
                         onTap: () => RouterStatic.pushToOotdDetail(
                             context,
-                            feed: element),
+                            feed: e.$2),
                         child: RecommendOotdWidget(
                           feedList: feedList,
-                          index: index,
+                          index: e.$1,
                         ),
                       )).toList()
                     ),

--- a/lib/presentation/home/screen/home_screen.dart
+++ b/lib/presentation/home/screen/home_screen.dart
@@ -1,6 +1,8 @@
+import 'package:cached_network_image/cached_network_image.dart';
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 import 'package:weaco/core/util/reaction_util.dart';
+import 'package:weaco/domain/feed/model/feed.dart';
 import 'package:weaco/presentation/common/style/image_path.dart';
 import 'package:weaco/core/enum/weather_code.dart';
 import 'package:weaco/presentation/common/enum/exception_alert.dart';
@@ -26,6 +28,12 @@ class _HomeScreenState extends State<HomeScreen> {
     Future.microtask(
       () async {
         await context.read<HomeScreenViewModel>().initHomeScreen();
+        final tmp = context.read<HomeScreenViewModel>().precacheList;
+        if (mounted) {
+          for (Feed e in tmp) {
+            await precacheImage(CachedNetworkImageProvider(e.thumbnailImagePath), context);
+          };
+        }
       },
     );
   }

--- a/lib/presentation/home/screen/home_screen.dart
+++ b/lib/presentation/home/screen/home_screen.dart
@@ -28,11 +28,11 @@ class _HomeScreenState extends State<HomeScreen> {
     Future.microtask(
       () async {
         await context.read<HomeScreenViewModel>().initHomeScreen();
-        final tmp = context.read<HomeScreenViewModel>().precacheList;
         if (mounted) {
+          final tmp = context.read<HomeScreenViewModel>().precacheList;
           for (Feed e in tmp) {
             await precacheImage(CachedNetworkImageProvider(e.thumbnailImagePath), context);
-          };
+          }
         }
       },
     );

--- a/lib/presentation/home/view_model/home_screen_view_model.dart
+++ b/lib/presentation/home/view_model/home_screen_view_model.dart
@@ -1,4 +1,6 @@
+import 'package:cached_network_image/cached_network_image.dart';
 import 'package:flutter/material.dart';
+import 'package:weaco/domain/feed/use_case/get_search_feeds_use_case.dart';
 import 'package:weaco/presentation/common/style/image_path.dart';
 import 'package:weaco/core/enum/weather_code.dart';
 import 'package:weaco/domain/feed/model/feed.dart';
@@ -26,16 +28,19 @@ class HomeScreenViewModel with ChangeNotifier {
     required this.getDailyLocationWeatherUseCase,
     required this.getBackgroundImageListUseCase,
     required this.getRecommendedFeedsUseCase,
+    required this.getSearchFeedsUseCase,
   });
 
   final GetDailyLocationWeatherUseCase getDailyLocationWeatherUseCase;
   final GetBackgroundImageListUseCase getBackgroundImageListUseCase;
   final GetRecommendedFeedsUseCase getRecommendedFeedsUseCase;
+  final GetSearchFeedsUseCase getSearchFeedsUseCase;
 
   DailyLocationWeather? _dailyLocationWeather;
   Weather? _currentWeather;
   List<Weather> _weatherByTimeList = [];
   List<Feed> _feedList = [];
+  List<Feed> _precacheList = [];
   HomeScreenStatus _status = HomeScreenStatus.idle;
   // 전일 대비 온도차
   double? _temperatureGap;
@@ -45,6 +50,7 @@ class HomeScreenViewModel with ChangeNotifier {
   Weather? get currentWeather => _currentWeather;
   double? get temperatureGap => _temperatureGap ?? 0;
   List<Feed> get feedList => _feedList;
+  List<Feed> get precacheList => _precacheList;
   HomeScreenStatus get status => _status;
   String get backgroundImagePath =>
       _weatherBackgroundImage ?? ImagePath.homeBackgroundSunny;
@@ -62,6 +68,7 @@ class HomeScreenViewModel with ChangeNotifier {
       _feedList = await getRecommendedFeedsUseCase.execute(
         dailyLocationWeather: _dailyLocationWeather!,
       );
+      _precacheList = await getSearchFeedsUseCase.execute();
 
       if (_dailyLocationWeather != null) {
         // 현재 시간에 맞는 날씨 예보 빼내기

--- a/lib/presentation/home/view_model/home_screen_view_model.dart
+++ b/lib/presentation/home/view_model/home_screen_view_model.dart
@@ -1,4 +1,3 @@
-import 'package:cached_network_image/cached_network_image.dart';
 import 'package:flutter/material.dart';
 import 'package:weaco/domain/feed/use_case/get_search_feeds_use_case.dart';
 import 'package:weaco/presentation/common/style/image_path.dart';


### PR DESCRIPTION
## :: 최근 작업 주제 (하나 이상의 주제를 선택해주세요.)
- [x] 기능 추가
- [ ] 리뷰 반영
- [ ] 리팩토링
- [ ] 버그 수정
- [ ] 컨벤션 수정

<br />

## :: 구현 목표 (해당 브랜치에서 구현하고자 하는 하나의 목표를 설정합니다.)
- 피드 검색 화면 최초 20개 피드 이미지 프리 캐싱 처리

<br />

## :: 구현 사항 설명 (작업한 내용을 상세하게 기록합니다.)
1. 홈화면 진입시, 검색 화면 피드 이미지 프리 캐싱
<br />

## :: 성장 포인트 (해당 기능을 구현하며 고민했던 사항이나 새로 알게된 부분, 어려웠던 점 등을 작성합니다.)
- 이미지 로딩이 느린 부분 중에서, 프리 캐싱을 적용할 만한 부분은 어디인가? (성능과 UX 사이의 트레이드오프) (by 종현).
- Flutter에서 이미지 캐싱하는 메커니즘에 대해 알 수 있었다(by 윤지).
- Image.network와 cached_network_image의 차이를 알게 되었고, 프리 캐싱을 통해서 UX가 크게 개선되는 것을 확인할 수 있었다.(by 날아)

<br />

## :: 기타 질문 및 특이 사항

